### PR TITLE
fix: register button disappears when disabled (adds visible border)

### DIFF
--- a/src/ui/src/auth/signup/auth.css
+++ b/src/ui/src/auth/signup/auth.css
@@ -608,6 +608,7 @@
   background: var(--surface);
   color: var(--mute-2);
   cursor: not-allowed;
+  border: 1.5px solid var(--rule-16);
 }
 .kz-auth .register .submit svg {
   width: 16px;


### PR DESCRIPTION
## Description

The disabled Register button on the signup form has `background: var(--surface)` = `#f1f0eb` which is nearly invisible against the white page background. Users perceive the button as "disappearing."

## Fix

Added `border: 1.5px solid var(--rule-16)` to the `:disabled` state so the button outline stays visible even when the form is incomplete.

## Before
Disabled button was solid light gray with no border — blends into the page.

## After
Disabled button now has a visible border so users can always see it.

Closes #69