### PR TITLE
[mobile] Redesign mobile results screens

### DIFF
--- a/NATIVE/app.config.js
+++ b/NATIVE/app.config.js
@@ -40,7 +40,6 @@ export default {
                 foregroundImage: "./assets/images/adaptive-icon.png",
                 backgroundColor: "#ffffff",
             },
-            edgeToEdgeEnabled: true,
             package: "com.kurazetu.app",
             config: {
                 googleMaps: {

--- a/NATIVE/app.config.js
+++ b/NATIVE/app.config.js
@@ -109,6 +109,7 @@ export default {
                 },
             ],
             "./plugins/withIosBuildFixes",
+            "./plugins/withAndroidSliderFix",
         ],
         experiments: {
             typedRoutes: true,

--- a/NATIVE/app/(tabs)/_layout.tsx
+++ b/NATIVE/app/(tabs)/_layout.tsx
@@ -49,6 +49,7 @@ export default function TabLayout() {
                 tabBarActiveTintColor: "#1A2C4E",
                 tabBarInactiveTintColor: "#8E8E93",
                 tabBarLabelStyle: styles.tabLabel,
+                tabBarItemStyle: styles.tabItem,
             }}
         >
             <Tabs.Screen
@@ -69,7 +70,7 @@ export default function TabLayout() {
             <Tabs.Screen
                 name="pollingCentersEdit"
                 options={{
-                    title: "Verify Results",
+                    title: "Verify",
                     tabBarIcon: ({focused, color, size}) => (
                         <TabBarIcon
                             IconComponent={User}
@@ -84,7 +85,7 @@ export default function TabLayout() {
             <Tabs.Screen
                 name="communityNotes"
                 options={{
-                    title: "Polling Station",
+                    title: "Stations",
                     tabBarIcon: ({focused, color, size}) => (
                         <TabBarIcon
                             IconComponent={ChartSplineIcon}
@@ -124,7 +125,11 @@ const styles = StyleSheet.create({
     },
     tabLabel: {
         fontFamily: "Inter-Medium",
-        fontSize: 11,
+        fontSize: 10,
+        lineHeight: 12,
+    },
+    tabItem: {
+        paddingHorizontal: 0,
     },
     iconContainer: {
         alignItems: "center",

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/AddFormModal.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/AddFormModal.tsx
@@ -1,25 +1,11 @@
-import {
-    Alert,
-    Modal,
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
-} from "react-native";
-import {Camera, Check, X} from "lucide-react-native";
-import {CameraView, useCameraPermissions} from "expo-camera";
+import {Alert} from "react-native";
 import {fetch} from "expo/fetch";
 import {File} from "expo-file-system";
-import React, {useEffect, useRef, useState} from "react";
+import {useEffect, useState} from "react";
 
-import {SafeAreaView} from "react-native-safe-area-context";
-import {StatusBar} from "expo-status-bar";
+import {Form34ACandidate, Form34ACaptureForm} from "./Form34ACaptureForm";
 import {TLevelTabs} from "@/app/types";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
-import {perk} from "@/app/_utils/colors";
 import useAuthStore from "@/app/_utils/authStore";
 import {useLocalSearchParams} from "expo-router";
 
@@ -45,36 +31,11 @@ interface AddFormModalProps {
     level: TLevelTabs;
 }
 
-interface IAspirantVotes {
-    id: number;
-    votes: number;
-}
-
 export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
-    const [permission, requestPermission] = useCameraPermissions();
-    const [showCamera, setShowCamera] = useState(false);
-    const [capturedImage, setCapturedImage] = useState<string | null>(null);
     const [candidates, setCandidates] = useState<IAspirant[]>([]);
-    const [candidateVotes, setCandidateVotes] = useState<IAspirantVotes[]>([]);
-    const [rejectedVotes, setRejectedVotes] = useState<number>(0);
-    const [disputedVotes, setDisputedVotes] = useState<number>(0);
-    const cameraRef = useRef<CameraView>(null);
 
     const {userToken} = useAuthStore();
-
     const {id} = useLocalSearchParams();
-    // console.log(id, "id in AddFormModal");
-
-    React.useEffect(() => {
-        if (visible) {
-            // Reset form when modal opens
-            setCandidateVotes([]);
-            setRejectedVotes(0);
-            setDisputedVotes(0);
-            setCapturedImage(null);
-            setShowCamera(false);
-        }
-    }, [visible]);
 
     useEffect(() => {
         const fetchCandidates = async () => {
@@ -90,66 +51,37 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                     },
                 );
                 const data = await response.json();
-                // console.log(data, "aspirants data in AddFormModal");
                 if (data && data.data) {
-                    const candidates = data.data;
-                    setCandidates(candidates);
-                    const initialVotes: IAspirantVotes[] = [];
-                    candidates.map((candidate: IAspirant) => {
-                        initialVotes.push({id: candidate.id, votes: 0});
-                    });
-                    setCandidateVotes(initialVotes);
+                    setCandidates(data.data);
                 }
             } catch (error) {
                 console.error("Error fetching candidates:", error);
             }
         };
         fetchCandidates();
-    }, [visible, id, level, userToken]); // Added dependencies
+    }, [visible, id, level, userToken]);
 
-    // function to return boolean if none of the candidates have votes
-    const hasVotesValidate = () => {
-        return candidateVotes.some((candidate) => candidate.votes > 0);
-    };
+    const formCandidates: Form34ACandidate[] = candidates.map((candidate) => ({
+        key: String(candidate.id),
+        name: `${candidate.first_name} ${candidate.last_name}`,
+        party: candidate.party,
+    }));
 
-    const takePicture = async () => {
-        if (cameraRef.current) {
-            try {
-                const photo = await cameraRef.current.takePictureAsync();
-                if (photo) {
-                    setCapturedImage(photo.uri);
-                    setShowCamera(false);
-                }
-            } catch (error) {
-                Alert.alert("Error", "Failed to take picture");
-            }
-        }
-    };
-
-    const calculateTotal = () => {
-        const candidateTotal = candidateVotes.reduce(
-            (total, candidate) => total + (candidate.votes || 0),
-            0,
-        );
-        const rejected = rejectedVotes || 0;
-        const disputed = disputedVotes || 0;
-        return candidateTotal + rejected + disputed;
-    };
-
-    const handleSubmit = () => {
-        if (!capturedImage) {
-            Alert.alert("Error", "Please capture a Form 34A image first");
-            return;
-        }
-
-        let data = {
-            polling_station: id,
-            level: level,
-            image: capturedImage,
-            votes: candidateVotes,
-            rejected_votes: rejectedVotes,
-            disputed_votes: disputedVotes,
-        };
+    const handleSubmit = ({
+        image,
+        votes,
+        rejectedVotes,
+        disputedVotes,
+    }: {
+        image: string;
+        votes: Record<string, number>;
+        rejectedVotes: number;
+        disputedVotes: number;
+    }) => {
+        const candidateVotes = candidates.map((candidate) => ({
+            id: candidate.id,
+            votes: votes[String(candidate.id)] ?? 0,
+        }));
 
         Alert.alert(
             "Submit Results",
@@ -159,15 +91,13 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                 {
                     text: "Submit",
                     onPress: () => {
-                        console.log("Submitting results:", data);
-
-                        let formData = new FormData();
+                        const formData = new FormData();
                         formData.append(
                             "data",
                             JSON.stringify({
                                 polling_station: id,
                                 level: level,
-                                image: capturedImage,
+                                image: image,
                                 votes: candidateVotes,
                                 rejected_votes: rejectedVotes,
                                 disputed_votes: disputedVotes,
@@ -177,9 +107,7 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                         // Expo's current FormData implementation accepts Blob-compatible
                         // values. The legacy React Native {uri, type, name} object causes
                         // "Unsupported FormDataPart implementation" on the simulator.
-                        formData.append("image", new File(capturedImage));
-
-                        console.log(formData, "formData in AddFormModal");
+                        formData.append("image", new File(image));
 
                         fetch(
                             `${apiBaseURL}/api/results/polling-station/create/${id}/${level}/`,
@@ -187,7 +115,6 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                                 method: "POST",
                                 headers: {
                                     Authorization: `Token ${userToken}`,
-
                                     Accept: "application/json",
                                 },
                                 body: formData,
@@ -199,8 +126,7 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                                 }
                                 return response.json();
                             })
-                            .then((data) => {
-                                console.log("server data in AddFormModal :", data);
+                            .then(() => {
                                 Alert.alert(
                                     "Success",
                                     "Results submitted successfully",
@@ -217,554 +143,15 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
         );
     };
 
-    const updateCandidateVotes = (id: number, votes: number) => {
-        console.log("\n");
-        console.log("updateCandidateVotes called with id:", id, "votes:", votes);
-        setCandidateVotes((prevVotes) => {
-            const updatedVotes = prevVotes.map((candidate) => {
-                if (candidate.id === id) {
-                    return {...candidate, votes: votes};
-                }
-                return candidate;
-            });
-            console.log(updatedVotes, "updatedCandidateVotes");
-            return updatedVotes;
-        });
-    };
-
-    const getVoteValue = (id: number) => {
-        const found = candidateVotes.find((c) => c.id === id);
-        return found ? found.votes : 0;
-    };
-
-    if (!permission) {
-        return null;
-    }
-
-    if (!permission.granted) {
-        return (
-            <Modal
-                visible={visible}
-                animationType="slide"
-                transparent={true}
-                statusBarTranslucent={true}
-            >
-                <StatusBar style="light" />
-                <View style={styles.permissionOverlay}>
-                    <SafeAreaView style={styles.permissionSafeArea}>
-                        <View style={styles.permissionContainer}>
-                            <View style={styles.permissionCard}>
-                                <Text style={styles.permissionText}>
-                                    We need camera permission to capture Form 34A
-                                </Text>
-                                <TouchableOpacity
-                                    style={styles.permissionButton}
-                                    onPress={requestPermission}
-                                >
-                                    <Text style={styles.permissionButtonText}>
-                                        Grant Permission
-                                    </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                    style={styles.permissionCancelButton}
-                                    onPress={onClose}
-                                >
-                                    <Text style={styles.cancelButtonText}>Cancel</Text>
-                                </TouchableOpacity>
-                            </View>
-                        </View>
-                    </SafeAreaView>
-                </View>
-            </Modal>
-        );
-    }
-
     return (
-        <Modal
+        <Form34ACaptureForm
             visible={visible}
-            animationType="slide"
-            presentationStyle="fullScreen"
-            statusBarTranslucent={Platform.OS === "android"}
-        >
-            <StatusBar style="dark" />
-            <SafeAreaView style={styles.container}>
-                <View style={styles.header}>
-                    <Text style={styles.title}>Submit results</Text>
-                    <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-                        <X size={16} color={perk.ink} />
-                    </TouchableOpacity>
-                </View>
-
-                {showCamera ? (
-                    <View style={styles.cameraContainer}>
-                        <CameraView
-                            ref={cameraRef}
-                            style={styles.camera}
-                            facing="back"
-                        />
-                        <View style={styles.cameraControls}>
-                            <TouchableOpacity
-                                style={styles.captureButton}
-                                onPress={takePicture}
-                            >
-                                <Camera size={32} color={perk.limeInk} />
-                            </TouchableOpacity>
-                        </View>
-                    </View>
-                ) : (
-                    <View style={styles.body}>
-                        <ScrollView
-                            style={styles.content}
-                            showsVerticalScrollIndicator={false}
-                        >
-                            <View style={styles.section}>
-                                <Text style={styles.sectionLabel}>
-                                    CAPTURE FORM 34A
-                                </Text>
-                                {capturedImage ? (
-                                    <View style={styles.capturedImageContainer}>
-                                        <Text style={styles.capturedText}>
-                                            ✓ Form 34A Captured
-                                        </Text>
-                                        <TouchableOpacity
-                                            style={styles.recaptureButton}
-                                            onPress={() => setShowCamera(true)}
-                                        >
-                                            <Text style={styles.recaptureText}>
-                                                Retake Photo
-                                            </Text>
-                                        </TouchableOpacity>
-                                    </View>
-                                ) : (
-                                    <TouchableOpacity
-                                        style={styles.cameraButton}
-                                        onPress={() => setShowCamera(true)}
-                                    >
-                                        <Camera size={16} color={perk.lime} />
-                                        <Text style={styles.cameraButtonText}>
-                                            Capture Form 34A
-                                        </Text>
-                                    </TouchableOpacity>
-                                )}
-                            </View>
-
-                            <View style={styles.section}>
-                                <Text style={styles.sectionLabel}>ENTER VOTE DATA</Text>
-
-                                {candidates.map((candidate) => {
-                                    const voteValue = getVoteValue(candidate.id);
-                                    return (
-                                        <View key={candidate.id} style={styles.voteRow}>
-                                            <View style={styles.candidateInfo}>
-                                                <Text style={styles.candidateName}>
-                                                    {candidate.first_name}{" "}
-                                                    {candidate.last_name}
-                                                </Text>
-                                                <Text style={styles.candidateParty}>
-                                                    {candidate.party}
-                                                </Text>
-                                            </View>
-                                            <TextInput
-                                                style={[
-                                                    styles.vbox,
-                                                    voteValue > 0 && styles.vboxSet,
-                                                ]}
-                                                value={
-                                                    voteValue === 0
-                                                        ? ""
-                                                        : String(voteValue)
-                                                }
-                                                onChangeText={(text) => {
-                                                    const cleanText = text.replace(
-                                                        /[^0-9]/g,
-                                                        "",
-                                                    );
-                                                    const numValue =
-                                                        cleanText === ""
-                                                            ? 0
-                                                            : Number(cleanText);
-                                                    updateCandidateVotes(
-                                                        candidate.id,
-                                                        numValue,
-                                                    );
-                                                }}
-                                                placeholder="0"
-                                                placeholderTextColor={perk.mute2}
-                                                keyboardType="numeric"
-                                            />
-                                        </View>
-                                    );
-                                })}
-
-                                <View style={styles.voteRow}>
-                                    <View style={styles.candidateInfo}>
-                                        <Text style={styles.candidateName}>
-                                            Rejected votes
-                                        </Text>
-                                    </View>
-                                    <TextInput
-                                        style={[
-                                            styles.vbox,
-                                            rejectedVotes > 0 && styles.vboxSet,
-                                        ]}
-                                        value={
-                                            rejectedVotes === 0
-                                                ? ""
-                                                : String(rejectedVotes)
-                                        }
-                                        onChangeText={(text) => {
-                                            const cleanText = text.replace(
-                                                /[^0-9]/g,
-                                                "",
-                                            );
-                                            const numValue =
-                                                cleanText === ""
-                                                    ? 0
-                                                    : Number(cleanText);
-                                            setRejectedVotes(numValue);
-                                        }}
-                                        placeholder="0"
-                                        placeholderTextColor={perk.mute2}
-                                        keyboardType="numeric"
-                                    />
-                                </View>
-
-                                <View style={styles.voteRow}>
-                                    <View style={styles.candidateInfo}>
-                                        <Text style={styles.candidateName}>
-                                            Disputed votes
-                                        </Text>
-                                    </View>
-                                    <TextInput
-                                        style={[
-                                            styles.vbox,
-                                            disputedVotes > 0 && styles.vboxSet,
-                                        ]}
-                                        value={
-                                            disputedVotes === 0
-                                                ? ""
-                                                : String(disputedVotes)
-                                        }
-                                        onChangeText={(text) => {
-                                            const cleanText = text.replace(
-                                                /[^0-9]/g,
-                                                "",
-                                            );
-                                            const numValue =
-                                                cleanText === ""
-                                                    ? 0
-                                                    : Number(cleanText);
-                                            setDisputedVotes(numValue);
-                                        }}
-                                        placeholder="0"
-                                        placeholderTextColor={perk.mute2}
-                                        keyboardType="numeric"
-                                    />
-                                </View>
-                            </View>
-                        </ScrollView>
-
-                        <View style={styles.stickyFooter}>
-                            <View style={styles.totalRow}>
-                                <Text style={styles.totalLabel}>Total votes</Text>
-                                <Text style={styles.totalValue}>
-                                    {calculateTotal().toLocaleString()}
-                                </Text>
-                            </View>
-                            <View style={styles.buttonContainer}>
-                                <TouchableOpacity
-                                    style={styles.cancelButton}
-                                    onPress={onClose}
-                                >
-                                    <Text style={styles.cancelButtonText}>Cancel</Text>
-                                </TouchableOpacity>
-
-                                <TouchableOpacity
-                                    style={[
-                                        styles.submitButton,
-                                        (!capturedImage || !hasVotesValidate()) &&
-                                            styles.disabledButton,
-                                    ]}
-                                    onPress={handleSubmit}
-                                    disabled={!capturedImage || !hasVotesValidate()}
-                                >
-                                    <Check size={18} color={perk.limeInk} />
-                                    <Text style={styles.submitButtonText}>Submit</Text>
-                                </TouchableOpacity>
-                            </View>
-                        </View>
-                    </View>
-                )}
-            </SafeAreaView>
-        </Modal>
+            onClose={onClose}
+            title="Submit results"
+            candidates={formCandidates}
+            onSubmit={handleSubmit}
+        />
     );
 }
 
 export default AddFormModal;
-
-const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: perk.card,
-    },
-    // Permission modal styles
-    permissionOverlay: {
-        position: "absolute",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: "rgba(13,13,13,0.85)",
-    },
-    permissionSafeArea: {
-        flex: 1,
-    },
-    permissionContainer: {
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-        paddingHorizontal: 16,
-    },
-    permissionCard: {
-        width: "100%",
-        maxWidth: 400,
-        backgroundColor: perk.card,
-        borderRadius: 16,
-        padding: 24,
-        alignItems: "center",
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.2,
-        shadowRadius: 8,
-        elevation: 5,
-    },
-    permissionText: {
-        fontSize: 18,
-        color: perk.ink,
-        textAlign: "center",
-        marginBottom: 24,
-        lineHeight: 24,
-    },
-    permissionButton: {
-        backgroundColor: perk.lime,
-        paddingVertical: 16,
-        paddingHorizontal: 32,
-        borderRadius: 12,
-        marginBottom: 16,
-        width: "100%",
-        alignItems: "center",
-    },
-    permissionButtonText: {
-        color: perk.limeInk,
-        fontSize: 16,
-        fontWeight: "800",
-    },
-    permissionCancelButton: {
-        paddingVertical: 16,
-        paddingHorizontal: 16,
-        borderRadius: 12,
-        backgroundColor: perk.surface,
-        alignItems: "center",
-        width: "100%",
-    },
-    // Sheet
-    header: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        paddingHorizontal: 16,
-        paddingVertical: 14,
-        backgroundColor: perk.card,
-    },
-    title: {
-        fontSize: 19,
-        fontWeight: "900",
-        letterSpacing: -0.4,
-        color: perk.ink,
-    },
-    closeButton: {
-        width: 30,
-        height: 30,
-        borderRadius: 15,
-        backgroundColor: perk.surface,
-        alignItems: "center",
-        justifyContent: "center",
-    },
-    cameraContainer: {
-        flex: 1,
-    },
-    camera: {
-        flex: 1,
-    },
-    cameraControls: {
-        position: "absolute",
-        bottom: 50,
-        left: 0,
-        right: 0,
-        alignItems: "center",
-    },
-    captureButton: {
-        width: 80,
-        height: 80,
-        borderRadius: 40,
-        backgroundColor: perk.lime,
-        justifyContent: "center",
-        alignItems: "center",
-    },
-    body: {
-        flex: 1,
-    },
-    content: {
-        flex: 1,
-    },
-    section: {
-        paddingHorizontal: 16,
-        paddingVertical: 12,
-    },
-    sectionLabel: {
-        fontFamily: "SpaceMono-Regular",
-        fontSize: 10,
-        fontWeight: "700",
-        letterSpacing: 1.8,
-        color: perk.mute,
-        marginBottom: 10,
-    },
-    cameraButton: {
-        flexDirection: "row",
-        backgroundColor: perk.ink,
-        paddingVertical: 13,
-        paddingHorizontal: 24,
-        borderRadius: 12,
-        justifyContent: "center",
-        alignItems: "center",
-        gap: 8,
-    },
-    cameraButtonText: {
-        color: perk.lime,
-        fontSize: 13,
-        fontWeight: "800",
-    },
-    capturedImageContainer: {
-        alignItems: "center",
-        gap: 8,
-    },
-    capturedText: {
-        fontSize: 14,
-        color: perk.greenDeep,
-        fontWeight: "700",
-    },
-    recaptureButton: {
-        paddingVertical: 8,
-        paddingHorizontal: 16,
-    },
-    recaptureText: {
-        color: perk.copperDeep,
-        fontSize: 13,
-        textDecorationLine: "underline",
-    },
-    voteRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        paddingVertical: 8,
-        borderTopWidth: 1,
-        borderTopColor: perk.rule08,
-    },
-    candidateInfo: {
-        flex: 1,
-    },
-    candidateName: {
-        fontSize: 12,
-        fontWeight: "800",
-        color: perk.ink,
-    },
-    candidateParty: {
-        fontFamily: "SpaceMono-Regular",
-        fontSize: 9,
-        color: perk.mute,
-        letterSpacing: 0.6,
-        marginTop: 1,
-        textTransform: "uppercase",
-    },
-    vbox: {
-        width: 50,
-        height: 34,
-        borderWidth: 1.5,
-        borderColor: perk.rule16,
-        borderRadius: 9,
-        paddingHorizontal: 4,
-        fontFamily: "SpaceMono-Regular",
-        fontSize: 12,
-        fontWeight: "700",
-        textAlign: "center",
-        color: perk.mute2,
-        backgroundColor: perk.card,
-    },
-    vboxSet: {
-        borderColor: perk.ink,
-        color: perk.ink,
-    },
-    stickyFooter: {
-        backgroundColor: perk.card,
-        borderTopWidth: 1.5,
-        borderTopColor: perk.ink,
-        paddingHorizontal: 16,
-        paddingTop: 10,
-        paddingBottom: 14,
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: -8},
-        shadowOpacity: 0.06,
-        shadowRadius: 12,
-        elevation: 8,
-    },
-    totalRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-    },
-    totalLabel: {
-        fontSize: 14,
-        fontWeight: "800",
-        color: perk.ink,
-    },
-    totalValue: {
-        fontSize: 20,
-        fontWeight: "900",
-        color: perk.coralDeep,
-    },
-    buttonContainer: {
-        flexDirection: "row",
-        gap: 8,
-        marginTop: 12,
-    },
-    cancelButton: {
-        flex: 0.7,
-        paddingVertical: 13,
-        borderRadius: 12,
-        backgroundColor: perk.surface,
-        alignItems: "center",
-    },
-    cancelButtonText: {
-        color: perk.ink,
-        fontSize: 13,
-        fontWeight: "800",
-    },
-    submitButton: {
-        flex: 1.3,
-        flexDirection: "row",
-        paddingVertical: 13,
-        borderRadius: 12,
-        backgroundColor: perk.lime,
-        justifyContent: "center",
-        alignItems: "center",
-        gap: 8,
-    },
-    submitButtonText: {
-        color: perk.limeInk,
-        fontSize: 13,
-        fontWeight: "800",
-    },
-    disabledButton: {
-        backgroundColor: perk.paperDeep,
-    },
-});

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/AddFormModal.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/AddFormModal.tsx
@@ -11,12 +11,15 @@ import {
 } from "react-native";
 import {Camera, Check, X} from "lucide-react-native";
 import {CameraView, useCameraPermissions} from "expo-camera";
+import {fetch} from "expo/fetch";
+import {File} from "expo-file-system";
 import React, {useEffect, useRef, useState} from "react";
 
 import {SafeAreaView} from "react-native-safe-area-context";
 import {StatusBar} from "expo-status-bar";
 import {TLevelTabs} from "@/app/types";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
+import {perk} from "@/app/_utils/colors";
 import useAuthStore from "@/app/_utils/authStore";
 import {useLocalSearchParams} from "expo-router";
 
@@ -171,11 +174,10 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                             }),
                         );
 
-                        formData.append("image", {
-                            uri: capturedImage,
-                            type: "image/jpeg",
-                            name: "form34a.jpg",
-                        });
+                        // Expo's current FormData implementation accepts Blob-compatible
+                        // values. The legacy React Native {uri, type, name} object causes
+                        // "Unsupported FormDataPart implementation" on the simulator.
+                        formData.append("image", new File(capturedImage));
 
                         console.log(formData, "formData in AddFormModal");
 
@@ -184,7 +186,6 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                             {
                                 method: "POST",
                                 headers: {
-                                    "Content-Type": "multipart/form-data",
                                     Authorization: `Token ${userToken}`,
 
                                     Accept: "application/json",
@@ -288,9 +289,9 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
             <StatusBar style="dark" />
             <SafeAreaView style={styles.container}>
                 <View style={styles.header}>
-                    <Text style={styles.title}>Submit Results</Text>
+                    <Text style={styles.title}>Submit results</Text>
                     <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-                        <X size={24} color="#000000" />
+                        <X size={16} color={perk.ink} />
                     </TouchableOpacity>
                 </View>
 
@@ -306,163 +307,193 @@ export function AddFormModal({visible, onClose, level}: AddFormModalProps) {
                                 style={styles.captureButton}
                                 onPress={takePicture}
                             >
-                                <Camera size={32} color="#FFFFFF" />
+                                <Camera size={32} color={perk.limeInk} />
                             </TouchableOpacity>
                         </View>
                     </View>
                 ) : (
-                    <ScrollView style={styles.content}>
-                        <View style={styles.section}>
-                            <Text style={styles.sectionTitle}>Capture Form 34A</Text>
-                            {capturedImage ? (
-                                <View style={styles.capturedImageContainer}>
-                                    <Text style={styles.capturedText}>
-                                        ✓ Form 34A Captured
-                                    </Text>
+                    <View style={styles.body}>
+                        <ScrollView
+                            style={styles.content}
+                            showsVerticalScrollIndicator={false}
+                        >
+                            <View style={styles.section}>
+                                <Text style={styles.sectionLabel}>
+                                    CAPTURE FORM 34A
+                                </Text>
+                                {capturedImage ? (
+                                    <View style={styles.capturedImageContainer}>
+                                        <Text style={styles.capturedText}>
+                                            ✓ Form 34A Captured
+                                        </Text>
+                                        <TouchableOpacity
+                                            style={styles.recaptureButton}
+                                            onPress={() => setShowCamera(true)}
+                                        >
+                                            <Text style={styles.recaptureText}>
+                                                Retake Photo
+                                            </Text>
+                                        </TouchableOpacity>
+                                    </View>
+                                ) : (
                                     <TouchableOpacity
-                                        style={styles.recaptureButton}
+                                        style={styles.cameraButton}
                                         onPress={() => setShowCamera(true)}
                                     >
-                                        <Text style={styles.recaptureText}>
-                                            Retake Photo
+                                        <Camera size={16} color={perk.lime} />
+                                        <Text style={styles.cameraButtonText}>
+                                            Capture Form 34A
                                         </Text>
                                     </TouchableOpacity>
-                                </View>
-                            ) : (
-                                <TouchableOpacity
-                                    style={styles.cameraButton}
-                                    onPress={() => setShowCamera(true)}
-                                >
-                                    <Camera size={24} color="#FFFFFF" />
-                                    <Text style={styles.cameraButtonText}>
-                                        Capture Form 34A
-                                    </Text>
-                                </TouchableOpacity>
-                            )}
-                        </View>
+                                )}
+                            </View>
 
-                        <View style={styles.section}>
-                            <Text style={styles.sectionTitle}>Enter Vote data</Text>
+                            <View style={styles.section}>
+                                <Text style={styles.sectionLabel}>ENTER VOTE DATA</Text>
 
-                            {candidates.map((candidate) => {
-                                const voteValue = getVoteValue(candidate.id);
-                                return (
-                                    <View
-                                        key={candidate.id}
-                                        style={styles.candidateRow}
-                                    >
-                                        <View style={styles.candidateInfo}>
-                                            <Text style={styles.candidateName}>
-                                                {candidate.first_name}{" "}
-                                                {candidate.last_name}
-                                            </Text>
-                                            <Text style={styles.candidateParty}>
-                                                {candidate.party}
-                                            </Text>
+                                {candidates.map((candidate) => {
+                                    const voteValue = getVoteValue(candidate.id);
+                                    return (
+                                        <View key={candidate.id} style={styles.voteRow}>
+                                            <View style={styles.candidateInfo}>
+                                                <Text style={styles.candidateName}>
+                                                    {candidate.first_name}{" "}
+                                                    {candidate.last_name}
+                                                </Text>
+                                                <Text style={styles.candidateParty}>
+                                                    {candidate.party}
+                                                </Text>
+                                            </View>
+                                            <TextInput
+                                                style={[
+                                                    styles.vbox,
+                                                    voteValue > 0 && styles.vboxSet,
+                                                ]}
+                                                value={
+                                                    voteValue === 0
+                                                        ? ""
+                                                        : String(voteValue)
+                                                }
+                                                onChangeText={(text) => {
+                                                    const cleanText = text.replace(
+                                                        /[^0-9]/g,
+                                                        "",
+                                                    );
+                                                    const numValue =
+                                                        cleanText === ""
+                                                            ? 0
+                                                            : Number(cleanText);
+                                                    updateCandidateVotes(
+                                                        candidate.id,
+                                                        numValue,
+                                                    );
+                                                }}
+                                                placeholder="0"
+                                                placeholderTextColor={perk.mute2}
+                                                keyboardType="numeric"
+                                            />
                                         </View>
-                                        <TextInput
-                                            style={styles.voteInput}
-                                            value={
-                                                voteValue === 0 ? "" : String(voteValue)
-                                            }
-                                            onChangeText={(text) => {
-                                                const cleanText = text.replace(
-                                                    /[^0-9]/g,
-                                                    "",
-                                                );
-                                                const numValue =
-                                                    cleanText === ""
-                                                        ? 0
-                                                        : Number(cleanText);
-                                                updateCandidateVotes(
-                                                    candidate.id,
-                                                    numValue,
-                                                );
-                                            }}
-                                            placeholder="0"
-                                            keyboardType="numeric"
-                                        />
+                                    );
+                                })}
+
+                                <View style={styles.voteRow}>
+                                    <View style={styles.candidateInfo}>
+                                        <Text style={styles.candidateName}>
+                                            Rejected votes
+                                        </Text>
                                     </View>
-                                );
-                            })}
-
-                            <View style={styles.candidateRow}>
-                                <View style={styles.candidateInfo}>
-                                    <Text style={styles.candidateName}>
-                                        Rejected Votes
-                                    </Text>
+                                    <TextInput
+                                        style={[
+                                            styles.vbox,
+                                            rejectedVotes > 0 && styles.vboxSet,
+                                        ]}
+                                        value={
+                                            rejectedVotes === 0
+                                                ? ""
+                                                : String(rejectedVotes)
+                                        }
+                                        onChangeText={(text) => {
+                                            const cleanText = text.replace(
+                                                /[^0-9]/g,
+                                                "",
+                                            );
+                                            const numValue =
+                                                cleanText === ""
+                                                    ? 0
+                                                    : Number(cleanText);
+                                            setRejectedVotes(numValue);
+                                        }}
+                                        placeholder="0"
+                                        placeholderTextColor={perk.mute2}
+                                        keyboardType="numeric"
+                                    />
                                 </View>
-                                <TextInput
-                                    style={styles.voteInput}
-                                    value={
-                                        rejectedVotes === 0 ? "" : String(rejectedVotes)
-                                    }
-                                    onChangeText={(text) => {
-                                        const cleanText = text.replace(/[^0-9]/g, "");
-                                        const numValue =
-                                            cleanText === "" ? 0 : Number(cleanText);
-                                        setRejectedVotes(numValue);
-                                    }}
-                                    placeholder="0"
-                                    keyboardType="numeric"
-                                />
-                            </View>
 
-                            <View style={styles.candidateRow}>
-                                <View style={styles.candidateInfo}>
-                                    <Text style={styles.candidateName}>
-                                        Disputed Votes
-                                    </Text>
+                                <View style={styles.voteRow}>
+                                    <View style={styles.candidateInfo}>
+                                        <Text style={styles.candidateName}>
+                                            Disputed votes
+                                        </Text>
+                                    </View>
+                                    <TextInput
+                                        style={[
+                                            styles.vbox,
+                                            disputedVotes > 0 && styles.vboxSet,
+                                        ]}
+                                        value={
+                                            disputedVotes === 0
+                                                ? ""
+                                                : String(disputedVotes)
+                                        }
+                                        onChangeText={(text) => {
+                                            const cleanText = text.replace(
+                                                /[^0-9]/g,
+                                                "",
+                                            );
+                                            const numValue =
+                                                cleanText === ""
+                                                    ? 0
+                                                    : Number(cleanText);
+                                            setDisputedVotes(numValue);
+                                        }}
+                                        placeholder="0"
+                                        placeholderTextColor={perk.mute2}
+                                        keyboardType="numeric"
+                                    />
                                 </View>
-                                <TextInput
-                                    style={styles.voteInput}
-                                    value={
-                                        disputedVotes === 0 ? "" : String(disputedVotes)
-                                    }
-                                    onChangeText={(text) => {
-                                        const cleanText = text.replace(/[^0-9]/g, "");
-                                        const numValue =
-                                            cleanText === "" ? 0 : Number(cleanText);
-                                        setDisputedVotes(numValue);
-                                    }}
-                                    placeholder="0"
-                                    keyboardType="numeric"
-                                />
                             </View>
+                        </ScrollView>
 
+                        <View style={styles.stickyFooter}>
                             <View style={styles.totalRow}>
-                                <Text style={styles.totalLabel}>Total Votes:</Text>
+                                <Text style={styles.totalLabel}>Total votes</Text>
                                 <Text style={styles.totalValue}>
                                     {calculateTotal().toLocaleString()}
                                 </Text>
                             </View>
-                        </View>
+                            <View style={styles.buttonContainer}>
+                                <TouchableOpacity
+                                    style={styles.cancelButton}
+                                    onPress={onClose}
+                                >
+                                    <Text style={styles.cancelButtonText}>Cancel</Text>
+                                </TouchableOpacity>
 
-                        <View style={styles.buttonContainer}>
-                            <TouchableOpacity
-                                style={styles.cancelButton}
-                                onPress={onClose}
-                            >
-                                <Text style={styles.cancelButtonText}>Cancel</Text>
-                            </TouchableOpacity>
-
-                            <TouchableOpacity
-                                style={[
-                                    styles.submitButton,
-                                    (!capturedImage || !hasVotesValidate()) &&
-                                        styles.disabledButton,
-                                ]}
-                                onPress={handleSubmit}
-                                disabled={!capturedImage || !hasVotesValidate()}
-                            >
-                                <Check size={20} color="#FFFFFF" />
-                                <Text style={styles.submitButtonText}>
-                                    Submit{" "}
-                                    {hasVotesValidate() && capturedImage ? "✓" : "✗"}
-                                </Text>
-                            </TouchableOpacity>
+                                <TouchableOpacity
+                                    style={[
+                                        styles.submitButton,
+                                        (!capturedImage || !hasVotesValidate()) &&
+                                            styles.disabledButton,
+                                    ]}
+                                    onPress={handleSubmit}
+                                    disabled={!capturedImage || !hasVotesValidate()}
+                                >
+                                    <Check size={18} color={perk.limeInk} />
+                                    <Text style={styles.submitButtonText}>Submit</Text>
+                                </TouchableOpacity>
+                            </View>
                         </View>
-                    </ScrollView>
+                    </View>
                 )}
             </SafeAreaView>
         </Modal>
@@ -474,16 +505,16 @@ export default AddFormModal;
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: "#FFFFFF",
+        backgroundColor: perk.card,
     },
-    // Permission modal styles - Fixed for Android
+    // Permission modal styles
     permissionOverlay: {
         position: "absolute",
         top: 0,
         left: 0,
         right: 0,
         bottom: 0,
-        backgroundColor: "rgba(0,0,255,0.85)",
+        backgroundColor: "rgba(13,13,13,0.85)",
     },
     permissionSafeArea: {
         flex: 1,
@@ -497,7 +528,7 @@ const styles = StyleSheet.create({
     permissionCard: {
         width: "100%",
         maxWidth: 400,
-        backgroundColor: "#fff",
+        backgroundColor: perk.card,
         borderRadius: 16,
         padding: 24,
         alignItems: "center",
@@ -509,50 +540,55 @@ const styles = StyleSheet.create({
     },
     permissionText: {
         fontSize: 18,
-        color: "#000000",
+        color: perk.ink,
         textAlign: "center",
         marginBottom: 24,
         lineHeight: 24,
     },
     permissionButton: {
-        backgroundColor: "#DC143C",
+        backgroundColor: perk.lime,
         paddingVertical: 16,
         paddingHorizontal: 32,
-        borderRadius: 8,
+        borderRadius: 12,
         marginBottom: 16,
         width: "100%",
         alignItems: "center",
     },
     permissionButtonText: {
-        color: "#FFFFFF",
+        color: perk.limeInk,
         fontSize: 16,
-        fontWeight: "600",
+        fontWeight: "800",
     },
     permissionCancelButton: {
         paddingVertical: 16,
         paddingHorizontal: 16,
-        borderRadius: 8,
-        backgroundColor: "#F5F5F5",
+        borderRadius: 12,
+        backgroundColor: perk.surface,
         alignItems: "center",
         width: "100%",
     },
-    // Rest of the existing styles
+    // Sheet
     header: {
         flexDirection: "row",
         justifyContent: "space-between",
         alignItems: "center",
-        padding: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
-        backgroundColor: "#FFFFFF",
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+        backgroundColor: perk.card,
     },
     title: {
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "#000000",
+        fontSize: 19,
+        fontWeight: "900",
+        letterSpacing: -0.4,
+        color: perk.ink,
     },
     closeButton: {
-        padding: 8,
+        width: 30,
+        height: 30,
+        borderRadius: 15,
+        backgroundColor: perk.surface,
+        alignItems: "center",
+        justifyContent: "center",
     },
     cameraContainer: {
         flex: 1,
@@ -571,141 +607,164 @@ const styles = StyleSheet.create({
         width: 80,
         height: 80,
         borderRadius: 40,
-        backgroundColor: "#DC143C",
+        backgroundColor: perk.lime,
         justifyContent: "center",
         alignItems: "center",
+    },
+    body: {
+        flex: 1,
     },
     content: {
         flex: 1,
     },
     section: {
-        padding: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
+        paddingHorizontal: 16,
+        paddingVertical: 12,
     },
-    sectionTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#000000",
-        marginBottom: 16,
+    sectionLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.8,
+        color: perk.mute,
+        marginBottom: 10,
     },
     cameraButton: {
         flexDirection: "row",
-        backgroundColor: "#DC143C",
-        paddingVertical: 16,
+        backgroundColor: perk.ink,
+        paddingVertical: 13,
         paddingHorizontal: 24,
-        borderRadius: 8,
+        borderRadius: 12,
         justifyContent: "center",
         alignItems: "center",
         gap: 8,
     },
     cameraButtonText: {
-        color: "#FFFFFF",
-        fontSize: 16,
-        fontWeight: "600",
+        color: perk.lime,
+        fontSize: 13,
+        fontWeight: "800",
     },
     capturedImageContainer: {
         alignItems: "center",
         gap: 8,
     },
     capturedText: {
-        fontSize: 16,
-        color: "#006600",
-        fontWeight: "600",
+        fontSize: 14,
+        color: perk.greenDeep,
+        fontWeight: "700",
     },
     recaptureButton: {
         paddingVertical: 8,
         paddingHorizontal: 16,
     },
     recaptureText: {
-        color: "#DC143C",
-        fontSize: 14,
+        color: perk.copperDeep,
+        fontSize: 13,
         textDecorationLine: "underline",
     },
-    candidateRow: {
+    voteRow: {
         flexDirection: "row",
         justifyContent: "space-between",
         alignItems: "center",
-        paddingVertical: 12,
-        borderBottomWidth: 1,
-        borderBottomColor: "#F0F0F0",
+        paddingVertical: 8,
+        borderTopWidth: 1,
+        borderTopColor: perk.rule08,
     },
     candidateInfo: {
         flex: 1,
     },
     candidateName: {
-        fontSize: 16,
-        fontWeight: "600",
-        color: "#000000",
+        fontSize: 12,
+        fontWeight: "800",
+        color: perk.ink,
     },
     candidateParty: {
-        fontSize: 14,
-        color: "#666666",
-        marginTop: 2,
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        color: perk.mute,
+        letterSpacing: 0.6,
+        marginTop: 1,
+        textTransform: "uppercase",
     },
-    voteInput: {
-        width: 80,
-        height: 40,
-        borderWidth: 1,
-        borderColor: "#E0E0E0",
-        borderRadius: 6,
-        paddingHorizontal: 12,
-        fontSize: 16,
+    vbox: {
+        width: 50,
+        height: 34,
+        borderWidth: 1.5,
+        borderColor: perk.rule16,
+        borderRadius: 9,
+        paddingHorizontal: 4,
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 12,
+        fontWeight: "700",
         textAlign: "center",
-        backgroundColor: "#FFFFFF",
+        color: perk.mute2,
+        backgroundColor: perk.card,
+    },
+    vboxSet: {
+        borderColor: perk.ink,
+        color: perk.ink,
+    },
+    stickyFooter: {
+        backgroundColor: perk.card,
+        borderTopWidth: 1.5,
+        borderTopColor: perk.ink,
+        paddingHorizontal: 16,
+        paddingTop: 10,
+        paddingBottom: 14,
+        shadowColor: "#000",
+        shadowOffset: {width: 0, height: -8},
+        shadowOpacity: 0.06,
+        shadowRadius: 12,
+        elevation: 8,
     },
     totalRow: {
         flexDirection: "row",
         justifyContent: "space-between",
         alignItems: "center",
-        paddingTop: 16,
-        marginTop: 16,
-        borderTopWidth: 1,
-        borderTopColor: "#E0E0E0",
     },
     totalLabel: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#000000",
+        fontSize: 14,
+        fontWeight: "800",
+        color: perk.ink,
     },
     totalValue: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#DC143C",
+        fontSize: 20,
+        fontWeight: "900",
+        color: perk.coralDeep,
     },
     buttonContainer: {
         flexDirection: "row",
-        padding: 16,
-        gap: 12,
+        gap: 8,
+        marginTop: 12,
     },
     cancelButton: {
-        flex: 1,
-        paddingVertical: 16,
-        borderRadius: 8,
-        backgroundColor: "#F5F5F5",
+        flex: 0.7,
+        paddingVertical: 13,
+        borderRadius: 12,
+        backgroundColor: perk.surface,
         alignItems: "center",
     },
     cancelButtonText: {
-        color: "#666666",
-        fontSize: 16,
-        fontWeight: "600",
+        color: perk.ink,
+        fontSize: 13,
+        fontWeight: "800",
     },
     submitButton: {
-        flex: 2,
+        flex: 1.3,
         flexDirection: "row",
-        paddingVertical: 16,
-        borderRadius: 8,
-        backgroundColor: "#006600",
+        paddingVertical: 13,
+        borderRadius: 12,
+        backgroundColor: perk.lime,
         justifyContent: "center",
         alignItems: "center",
         gap: 8,
     },
     submitButtonText: {
-        color: "#FFFFFF",
-        fontSize: 16,
-        fontWeight: "600",
+        color: perk.limeInk,
+        fontSize: 13,
+        fontWeight: "800",
     },
     disabledButton: {
-        backgroundColor: "#CCCCCC",
+        backgroundColor: perk.paperDeep,
     },
 });

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/CounterEvidenceModal.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/CounterEvidenceModal.tsx
@@ -1,21 +1,6 @@
-import {
-    Alert,
-    Dimensions,
-    Modal,
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
-} from "react-native";
-import {Camera, Check, X} from "lucide-react-native";
-import {CameraType, CameraView, useCameraPermissions} from "expo-camera";
-import React, {useRef, useState} from "react";
+import {Alert} from "react-native";
 
-import {SafeAreaView} from "react-native-safe-area-context";
-import {StatusBar} from "expo-status-bar";
+import {Form34ACandidate, Form34ACaptureForm} from "./Form34ACaptureForm";
 
 interface Candidate {
     name: string;
@@ -49,81 +34,42 @@ export function CounterEvidenceModal({
     onClose,
     originalResults,
 }: CounterEvidenceModalProps) {
-    const [permission, requestPermission] = useCameraPermissions();
-    const [showCamera, setShowCamera] = useState(false);
-    const [capturedImage, setCapturedImage] = useState<string | null>(null);
-    const [candidateVotes, setCandidateVotes] = useState<{
-        [key: string]: string;
-    }>({});
-    const [rejectedVotes, setRejectedVotes] = useState("");
-    const [disputedVotes, setDisputedVotes] = useState("");
-    const cameraRef = useRef<CameraView>(null);
+    const formCandidates: Form34ACandidate[] = originalResults.candidates.map(
+        (candidate) => ({
+            key: candidate.name,
+            name: candidate.name,
+            party: candidate.party,
+        }),
+    );
 
-    React.useEffect(() => {
-        if (visible) {
-            // Reset form when modal opens
-            setCandidateVotes({});
-            setRejectedVotes("");
-            setDisputedVotes("");
-            setCapturedImage(null);
-            setShowCamera(false);
-        }
-    }, [visible]);
-
-    const takePicture = async () => {
-        if (cameraRef.current) {
-            try {
-                const photo = await cameraRef.current.takePictureAsync();
-                if (photo) {
-                    setCapturedImage(photo.uri);
-                    setShowCamera(false);
-                }
-            } catch (error) {
-                Alert.alert("Error", "Failed to take picture");
-            }
-        }
-    };
-
-    const calculateTotal = () => {
-        const candidateTotal = Object.values(candidateVotes).reduce(
-            (sum, votes) => sum + (parseInt(votes) || 0),
-            0,
-        );
-        const rejected = parseInt(rejectedVotes) || 0;
-        const disputed = parseInt(disputedVotes) || 0;
-        return candidateTotal + rejected + disputed;
-    };
-
-    const areResultsIdentical = () => {
-        // Check if all candidate votes match
+    // True when the entered tally is identical to the original submission —
+    // in that case there is no counter-evidence to add.
+    const isIdentical = (
+        votes: Record<string, number>,
+        rejectedVotes: number,
+        disputedVotes: number,
+    ) => {
         for (const candidate of originalResults.candidates) {
-            const inputVotes = parseInt(candidateVotes[candidate.name]) || 0;
-            if (inputVotes !== candidate.votes) {
+            if ((votes[candidate.name] ?? 0) !== candidate.votes) {
                 return false;
             }
         }
-
-        // Check rejected and disputed votes
-        const inputRejected = parseInt(rejectedVotes) || 0;
-        const inputDisputed = parseInt(disputedVotes) || 0;
-
-        if (
-            inputRejected !== originalResults.rejectedVotes ||
-            inputDisputed !== originalResults.disputedVotes
-        ) {
-            return false;
-        }
-
-        return true;
+        return (
+            rejectedVotes === originalResults.rejectedVotes &&
+            disputedVotes === originalResults.disputedVotes
+        );
     };
 
-    const handleSubmit = () => {
-        if (!capturedImage) {
-            Alert.alert("Error", "Please capture a Form 34A image first");
-            return;
-        }
-
-        if (areResultsIdentical()) {
+    const handleSubmit = ({
+        votes,
+        rejectedVotes,
+        disputedVotes,
+    }: {
+        votes: Record<string, number>;
+        rejectedVotes: number;
+        disputedVotes: number;
+    }) => {
+        if (isIdentical(votes, rejectedVotes, disputedVotes)) {
             Alert.alert(
                 "Results Match",
                 "Your submitted results match the original submission. No counter-evidence needed.",
@@ -139,7 +85,7 @@ export function CounterEvidenceModal({
                 {
                     text: "Submit",
                     onPress: () => {
-                        // Handle submission logic here
+                        // TODO: wire counter-evidence submission to the API.
                         Alert.alert(
                             "Success",
                             "Counter-evidence submitted successfully",
@@ -151,453 +97,19 @@ export function CounterEvidenceModal({
         );
     };
 
-    if (!permission) {
-        return null;
-    }
-
-    if (!permission.granted) {
-        return (
-            <Modal
-                visible={visible}
-                animationType="slide"
-                transparent={true}
-                statusBarTranslucent={true}
-            >
-                <StatusBar style="light" />
-                <View style={styles.permissionOverlay}>
-                    <SafeAreaView style={styles.permissionSafeArea}>
-                        <View style={styles.permissionContainer}>
-                            <View style={styles.permissionCard}>
-                                <Text style={styles.permissionText}>
-                                    We need camera permission to capture Form 34A
-                                </Text>
-                                <TouchableOpacity
-                                    style={styles.permissionButton}
-                                    onPress={requestPermission}
-                                >
-                                    <Text style={styles.permissionButtonText}>
-                                        Grant Permission
-                                    </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                    style={styles.permissionCancelButton}
-                                    onPress={onClose}
-                                >
-                                    <Text style={styles.cancelButtonText}>Cancel</Text>
-                                </TouchableOpacity>
-                            </View>
-                        </View>
-                    </SafeAreaView>
-                </View>
-            </Modal>
-        );
-    }
-
     return (
-        <Modal
+        <Form34ACaptureForm
             visible={visible}
-            animationType="slide"
-            presentationStyle="fullScreen"
-            statusBarTranslucent={Platform.OS === "android"}
-        >
-            <StatusBar style="dark" />
-            <SafeAreaView style={styles.container}>
-                <View style={styles.header}>
-                    <Text style={styles.title}>Submit Counter-Evidence</Text>
-                    <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-                        <X size={24} color="#000000" />
-                    </TouchableOpacity>
-                </View>
-
-                {showCamera ? (
-                    <View style={styles.cameraContainer}>
-                        <CameraView
-                            ref={cameraRef}
-                            style={styles.camera}
-                            facing="back"
-                        />
-                        <View style={styles.cameraControls}>
-                            <TouchableOpacity
-                                style={styles.captureButton}
-                                onPress={takePicture}
-                            >
-                                <Camera size={32} color="#FFFFFF" />
-                            </TouchableOpacity>
-                        </View>
-                    </View>
-                ) : (
-                    <ScrollView style={styles.content}>
-                        <View style={styles.section}>
-                            <Text style={styles.sectionTitle}>Capture Form 34A</Text>
-                            {capturedImage ? (
-                                <View style={styles.capturedImageContainer}>
-                                    <Text style={styles.capturedText}>
-                                        ✓ Form 34A Captured
-                                    </Text>
-                                    <TouchableOpacity
-                                        style={styles.recaptureButton}
-                                        onPress={() => setShowCamera(true)}
-                                    >
-                                        <Text style={styles.recaptureText}>
-                                            Retake Photo
-                                        </Text>
-                                    </TouchableOpacity>
-                                </View>
-                            ) : (
-                                <TouchableOpacity
-                                    style={styles.cameraButton}
-                                    onPress={() => setShowCamera(true)}
-                                >
-                                    <Camera size={24} color="#FFFFFF" />
-                                    <Text style={styles.cameraButtonText}>
-                                        Capture Form 34A
-                                    </Text>
-                                </TouchableOpacity>
-                            )}
-                        </View>
-
-                        <View style={styles.section}>
-                            <Text style={styles.sectionTitle}>Enter Vote Counts</Text>
-
-                            {originalResults.candidates.map((candidate, index) => (
-                                <View key={index} style={styles.candidateRow}>
-                                    <View style={styles.candidateInfo}>
-                                        <Text style={styles.candidateName}>
-                                            {candidate.name}
-                                        </Text>
-                                        <Text style={styles.candidateParty}>
-                                            {candidate.party}
-                                        </Text>
-                                    </View>
-                                    <TextInput
-                                        style={styles.voteInput}
-                                        value={candidateVotes[candidate.name] || ""}
-                                        onChangeText={(text) =>
-                                            setCandidateVotes((prev) => ({
-                                                ...prev,
-                                                [candidate.name]: text.replace(
-                                                    /[^0-9]/g,
-                                                    "",
-                                                ),
-                                            }))
-                                        }
-                                        placeholder="0"
-                                        keyboardType="numeric"
-                                    />
-                                </View>
-                            ))}
-
-                            <View style={styles.candidateRow}>
-                                <View style={styles.candidateInfo}>
-                                    <Text style={styles.candidateName}>
-                                        Rejected Votes
-                                    </Text>
-                                </View>
-                                <TextInput
-                                    style={styles.voteInput}
-                                    value={rejectedVotes}
-                                    onChangeText={(text) =>
-                                        setRejectedVotes(text.replace(/[^0-9]/g, ""))
-                                    }
-                                    placeholder="0"
-                                    keyboardType="numeric"
-                                />
-                            </View>
-
-                            <View style={styles.candidateRow}>
-                                <View style={styles.candidateInfo}>
-                                    <Text style={styles.candidateName}>
-                                        Disputed Votes
-                                    </Text>
-                                </View>
-                                <TextInput
-                                    style={styles.voteInput}
-                                    value={disputedVotes}
-                                    onChangeText={(text) =>
-                                        setDisputedVotes(text.replace(/[^0-9]/g, ""))
-                                    }
-                                    placeholder="0"
-                                    keyboardType="numeric"
-                                />
-                            </View>
-
-                            <View style={styles.totalRow}>
-                                <Text style={styles.totalLabel}>Total Votes:</Text>
-                                <Text style={styles.totalValue}>
-                                    {calculateTotal().toLocaleString()}
-                                </Text>
-                            </View>
-                        </View>
-
-                        <View style={styles.buttonContainer}>
-                            <TouchableOpacity
-                                style={styles.cancelButton}
-                                onPress={onClose}
-                            >
-                                <Text style={styles.cancelButtonText}>Cancel</Text>
-                            </TouchableOpacity>
-
-                            <TouchableOpacity
-                                style={[
-                                    styles.submitButton,
-                                    (!capturedImage || areResultsIdentical()) &&
-                                        styles.disabledButton,
-                                ]}
-                                onPress={handleSubmit}
-                                disabled={!capturedImage || areResultsIdentical()}
-                            >
-                                <Check size={20} color="#FFFFFF" />
-                                <Text style={styles.submitButtonText}>
-                                    {areResultsIdentical()
-                                        ? "Results Match Original"
-                                        : "Submit"}
-                                </Text>
-                            </TouchableOpacity>
-                        </View>
-                    </ScrollView>
-                )}
-            </SafeAreaView>
-        </Modal>
+            onClose={onClose}
+            title="Submit counter-evidence"
+            submitLabel="Submit"
+            candidates={formCandidates}
+            canSubmit={({votes, rejectedVotes, disputedVotes}) =>
+                !isIdentical(votes, rejectedVotes, disputedVotes)
+            }
+            onSubmit={handleSubmit}
+        />
     );
 }
 
 export default CounterEvidenceModal;
-
-const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: "#FFFFFF",
-    },
-    // Permission modal styles - Fixed for Android
-    permissionOverlay: {
-        position: "absolute",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: "rgba(0,0,255,0.85)",
-    },
-    permissionSafeArea: {
-        flex: 1,
-    },
-    permissionContainer: {
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-        paddingHorizontal: 16,
-    },
-    permissionCard: {
-        width: "100%",
-        maxWidth: 400,
-        backgroundColor: "#fff",
-        borderRadius: 16,
-        padding: 24,
-        alignItems: "center",
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.2,
-        shadowRadius: 8,
-        elevation: 5,
-    },
-    permissionText: {
-        fontSize: 18,
-        color: "#000000",
-        textAlign: "center",
-        marginBottom: 24,
-        lineHeight: 24,
-    },
-    permissionButton: {
-        backgroundColor: "#DC143C",
-        paddingVertical: 16,
-        paddingHorizontal: 32,
-        borderRadius: 8,
-        marginBottom: 16,
-        width: "100%",
-        alignItems: "center",
-    },
-    permissionButtonText: {
-        color: "#FFFFFF",
-        fontSize: 16,
-        fontWeight: "600",
-    },
-    permissionCancelButton: {
-        paddingVertical: 16,
-        paddingHorizontal: 16,
-        borderRadius: 8,
-        backgroundColor: "#F5F5F5",
-        alignItems: "center",
-        width: "100%",
-    },
-    // Rest of the existing styles
-    header: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        padding: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
-        backgroundColor: "#FFFFFF",
-    },
-    title: {
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "#000000",
-    },
-    closeButton: {
-        padding: 8,
-    },
-    cameraContainer: {
-        flex: 1,
-    },
-    camera: {
-        flex: 1,
-    },
-    cameraControls: {
-        position: "absolute",
-        bottom: 50,
-        left: 0,
-        right: 0,
-        alignItems: "center",
-    },
-    captureButton: {
-        width: 80,
-        height: 80,
-        borderRadius: 40,
-        backgroundColor: "#DC143C",
-        justifyContent: "center",
-        alignItems: "center",
-    },
-    content: {
-        flex: 1,
-    },
-    section: {
-        padding: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
-    },
-    sectionTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#000000",
-        marginBottom: 16,
-    },
-    cameraButton: {
-        flexDirection: "row",
-        backgroundColor: "#DC143C",
-        paddingVertical: 16,
-        paddingHorizontal: 24,
-        borderRadius: 8,
-        justifyContent: "center",
-        alignItems: "center",
-        gap: 8,
-    },
-    cameraButtonText: {
-        color: "#FFFFFF",
-        fontSize: 16,
-        fontWeight: "600",
-    },
-    capturedImageContainer: {
-        alignItems: "center",
-        gap: 8,
-    },
-    capturedText: {
-        fontSize: 16,
-        color: "#006600",
-        fontWeight: "600",
-    },
-    recaptureButton: {
-        paddingVertical: 8,
-        paddingHorizontal: 16,
-    },
-    recaptureText: {
-        color: "#DC143C",
-        fontSize: 14,
-        textDecorationLine: "underline",
-    },
-    candidateRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        paddingVertical: 12,
-        borderBottomWidth: 1,
-        borderBottomColor: "#F0F0F0",
-    },
-    candidateInfo: {
-        flex: 1,
-    },
-    candidateName: {
-        fontSize: 16,
-        fontWeight: "600",
-        color: "#000000",
-    },
-    candidateParty: {
-        fontSize: 14,
-        color: "#666666",
-        marginTop: 2,
-    },
-    voteInput: {
-        width: 80,
-        height: 40,
-        borderWidth: 1,
-        borderColor: "#E0E0E0",
-        borderRadius: 6,
-        paddingHorizontal: 12,
-        fontSize: 16,
-        textAlign: "center",
-        backgroundColor: "#FFFFFF",
-    },
-    totalRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        paddingTop: 16,
-        marginTop: 16,
-        borderTopWidth: 1,
-        borderTopColor: "#E0E0E0",
-    },
-    totalLabel: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#000000",
-    },
-    totalValue: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#DC143C",
-    },
-    buttonContainer: {
-        flexDirection: "row",
-        padding: 16,
-        gap: 12,
-    },
-    cancelButton: {
-        flex: 1,
-        paddingVertical: 16,
-        borderRadius: 8,
-        backgroundColor: "#F5F5F5",
-        alignItems: "center",
-    },
-    cancelButtonText: {
-        color: "#666666",
-        fontSize: 16,
-        fontWeight: "600",
-    },
-    submitButton: {
-        flex: 2,
-        flexDirection: "row",
-        paddingVertical: 16,
-        borderRadius: 8,
-        backgroundColor: "#006600",
-        justifyContent: "center",
-        alignItems: "center",
-        gap: 8,
-    },
-    submitButtonText: {
-        color: "#FFFFFF",
-        fontSize: 16,
-        fontWeight: "600",
-    },
-    disabledButton: {
-        backgroundColor: "#CCCCCC",
-    },
-});

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/Form34ACaptureForm.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/Form34ACaptureForm.tsx
@@ -1,0 +1,641 @@
+import {
+    Modal,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import {Camera, Check, X} from "lucide-react-native";
+import {CameraView, useCameraPermissions} from "expo-camera";
+import React, {useState} from "react";
+import {SafeAreaProvider, SafeAreaView} from "react-native-safe-area-context";
+
+import {StatusBar} from "expo-status-bar";
+import {perk} from "@/app/_utils/colors";
+
+export interface Form34ACandidate {
+    key: string;
+    name: string;
+    party?: string | null;
+}
+
+export interface Form34ASubmission {
+    image: string;
+    votes: Record<string, number>;
+    rejectedVotes: number;
+    disputedVotes: number;
+    total: number;
+}
+
+interface Form34ACaptureFormProps {
+    visible: boolean;
+    onClose: () => void;
+    title: string;
+    candidates: Form34ACandidate[];
+    submitLabel?: string;
+    onSubmit: (submission: Form34ASubmission) => void;
+    /**
+     * Extra gate beyond the built-in rule (a photo plus at least one vote).
+     * Return false to keep the submit button disabled.
+     */
+    canSubmit?: (state: {
+        votes: Record<string, number>;
+        rejectedVotes: number;
+        disputedVotes: number;
+        hasImage: boolean;
+    }) => boolean;
+}
+
+/**
+ * Shared Form 34A capture + vote-entry sheet. Owns the camera, the per-candidate
+ * vote inputs and the running total; the parent supplies the candidate list and
+ * handles what happens on submit (API upload, counter-evidence check, ...).
+ */
+export function Form34ACaptureForm({
+    visible,
+    onClose,
+    title,
+    candidates,
+    submitLabel = "Submit",
+    onSubmit,
+    canSubmit,
+}: Form34ACaptureFormProps) {
+    const [permission, requestPermission] = useCameraPermissions();
+    const [showCamera, setShowCamera] = useState(false);
+    const [capturedImage, setCapturedImage] = useState<string | null>(null);
+    const [votes, setVotes] = useState<Record<string, number>>({});
+    const [rejectedVotes, setRejectedVotes] = useState(0);
+    const [disputedVotes, setDisputedVotes] = useState(0);
+    const [wasVisible, setWasVisible] = useState(false);
+    const cameraRef = React.useRef<CameraView>(null);
+
+    // Reset the form each time the sheet opens (render-phase state adjustment).
+    if (visible && !wasVisible) {
+        setWasVisible(true);
+        setVotes({});
+        setRejectedVotes(0);
+        setDisputedVotes(0);
+        setCapturedImage(null);
+        setShowCamera(false);
+    } else if (!visible && wasVisible) {
+        setWasVisible(false);
+    }
+
+    const getVote = (key: string) => votes[key] ?? 0;
+
+    const setVote = (key: string, value: number) =>
+        setVotes((prev) => ({...prev, [key]: value}));
+
+    const total =
+        Object.values(votes).reduce((sum, v) => sum + (v || 0), 0) +
+        rejectedVotes +
+        disputedVotes;
+
+    const hasVotes = Object.values(votes).some((v) => v > 0);
+    const extraGate = canSubmit
+        ? canSubmit({votes, rejectedVotes, disputedVotes, hasImage: !!capturedImage})
+        : true;
+    const submitEnabled = !!capturedImage && hasVotes && extraGate;
+
+    const takePicture = async () => {
+        if (!cameraRef.current) return;
+        try {
+            const photo = await cameraRef.current.takePictureAsync();
+            if (photo) {
+                setCapturedImage(photo.uri);
+                setShowCamera(false);
+            }
+        } catch {
+            // Swallow: the capture button stays available for a retry.
+        }
+    };
+
+    const parseCount = (text: string) => {
+        const clean = text.replace(/[^0-9]/g, "");
+        return clean === "" ? 0 : Number(clean);
+    };
+
+    if (!permission) {
+        return null;
+    }
+
+    if (!permission.granted) {
+        return (
+            <Modal
+                visible={visible}
+                animationType="slide"
+                transparent
+                statusBarTranslucent
+            >
+                <StatusBar style="light" />
+                <SafeAreaProvider>
+                    <View style={styles.permissionOverlay}>
+                        <SafeAreaView style={styles.permissionSafeArea}>
+                            <View style={styles.permissionContainer}>
+                                <View style={styles.permissionCard}>
+                                    <Text style={styles.permissionText}>
+                                        We need camera permission to capture Form 34A
+                                    </Text>
+                                    <TouchableOpacity
+                                        style={styles.permissionButton}
+                                        onPress={requestPermission}
+                                    >
+                                        <Text style={styles.permissionButtonText}>
+                                            Grant Permission
+                                        </Text>
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                        style={styles.permissionCancelButton}
+                                        onPress={onClose}
+                                    >
+                                        <Text style={styles.cancelButtonText}>
+                                            Cancel
+                                        </Text>
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </SafeAreaView>
+                    </View>
+                </SafeAreaProvider>
+            </Modal>
+        );
+    }
+
+    return (
+        <Modal
+            visible={visible}
+            animationType="slide"
+            presentationStyle="fullScreen"
+            statusBarTranslucent={Platform.OS === "android"}
+        >
+            <StatusBar style="dark" />
+            <SafeAreaProvider>
+                <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+                    <View style={styles.header}>
+                        <Text style={styles.title}>{title}</Text>
+                        <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+                            <X size={16} color={perk.ink} />
+                        </TouchableOpacity>
+                    </View>
+
+                    {showCamera ? (
+                        <View style={styles.cameraContainer}>
+                            <CameraView
+                                ref={cameraRef}
+                                style={styles.camera}
+                                facing="back"
+                            />
+                            <View style={styles.cameraControls}>
+                                <TouchableOpacity
+                                    style={styles.captureButton}
+                                    onPress={takePicture}
+                                >
+                                    <Camera size={32} color={perk.limeInk} />
+                                </TouchableOpacity>
+                            </View>
+                        </View>
+                    ) : (
+                        <View style={styles.body}>
+                            <ScrollView
+                                style={styles.content}
+                                contentContainerStyle={styles.contentInner}
+                                showsVerticalScrollIndicator={false}
+                            >
+                                <Text style={styles.sectionLabel}>
+                                    CAPTURE FORM 34A
+                                </Text>
+                                {capturedImage ? (
+                                    <View style={styles.capturedRow}>
+                                        <Text style={styles.capturedText}>
+                                            ✓ Form 34A captured
+                                        </Text>
+                                        <TouchableOpacity
+                                            onPress={() => setShowCamera(true)}
+                                        >
+                                            <Text style={styles.recaptureText}>
+                                                Retake
+                                            </Text>
+                                        </TouchableOpacity>
+                                    </View>
+                                ) : (
+                                    <TouchableOpacity
+                                        style={styles.cameraButton}
+                                        onPress={() => setShowCamera(true)}
+                                    >
+                                        <Camera size={16} color={perk.lime} />
+                                        <Text style={styles.cameraButtonText}>
+                                            Capture Form 34A
+                                        </Text>
+                                    </TouchableOpacity>
+                                )}
+
+                                <Text style={[styles.sectionLabel, {marginTop: 18}]}>
+                                    ENTER VOTE DATA
+                                </Text>
+                                {candidates.map((candidate) => {
+                                    const value = getVote(candidate.key);
+                                    return (
+                                        <View
+                                            key={candidate.key}
+                                            style={styles.voteRow}
+                                        >
+                                            <View style={styles.voteWho}>
+                                                <Text
+                                                    style={styles.voteName}
+                                                    numberOfLines={1}
+                                                >
+                                                    {candidate.name}
+                                                </Text>
+                                                {!!candidate.party && (
+                                                    <Text
+                                                        style={styles.voteParty}
+                                                        numberOfLines={1}
+                                                    >
+                                                        {candidate.party}
+                                                    </Text>
+                                                )}
+                                            </View>
+                                            <TextInput
+                                                style={[
+                                                    styles.vbox,
+                                                    value > 0 && styles.vboxSet,
+                                                ]}
+                                                value={value === 0 ? "" : String(value)}
+                                                onChangeText={(t) =>
+                                                    setVote(
+                                                        candidate.key,
+                                                        parseCount(t),
+                                                    )
+                                                }
+                                                placeholder="0"
+                                                placeholderTextColor={perk.mute2}
+                                                keyboardType="numeric"
+                                            />
+                                        </View>
+                                    );
+                                })}
+
+                                <View style={styles.voteRow}>
+                                    <View style={styles.voteWho}>
+                                        <Text style={styles.voteName}>
+                                            Rejected votes
+                                        </Text>
+                                    </View>
+                                    <TextInput
+                                        style={[
+                                            styles.vbox,
+                                            rejectedVotes > 0 && styles.vboxSet,
+                                        ]}
+                                        value={
+                                            rejectedVotes === 0
+                                                ? ""
+                                                : String(rejectedVotes)
+                                        }
+                                        onChangeText={(t) =>
+                                            setRejectedVotes(parseCount(t))
+                                        }
+                                        placeholder="0"
+                                        placeholderTextColor={perk.mute2}
+                                        keyboardType="numeric"
+                                    />
+                                </View>
+
+                                <View style={styles.voteRow}>
+                                    <View style={styles.voteWho}>
+                                        <Text style={styles.voteName}>
+                                            Disputed votes
+                                        </Text>
+                                    </View>
+                                    <TextInput
+                                        style={[
+                                            styles.vbox,
+                                            disputedVotes > 0 && styles.vboxSet,
+                                        ]}
+                                        value={
+                                            disputedVotes === 0
+                                                ? ""
+                                                : String(disputedVotes)
+                                        }
+                                        onChangeText={(t) =>
+                                            setDisputedVotes(parseCount(t))
+                                        }
+                                        placeholder="0"
+                                        placeholderTextColor={perk.mute2}
+                                        keyboardType="numeric"
+                                    />
+                                </View>
+                            </ScrollView>
+
+                            {/* Floating footer sheet */}
+                            <View style={styles.footer}>
+                                <View style={styles.totalRow}>
+                                    <Text style={styles.totalLabel}>Total votes</Text>
+                                    <Text style={styles.totalValue}>
+                                        {total.toLocaleString()}
+                                    </Text>
+                                </View>
+                                <View style={styles.footerButtons}>
+                                    <TouchableOpacity
+                                        style={styles.cancelButton}
+                                        onPress={onClose}
+                                    >
+                                        <Text style={styles.cancelButtonText}>
+                                            Cancel
+                                        </Text>
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                        style={[
+                                            styles.submitButton,
+                                            !submitEnabled && styles.disabledButton,
+                                        ]}
+                                        disabled={!submitEnabled}
+                                        onPress={() =>
+                                            onSubmit({
+                                                image: capturedImage as string,
+                                                votes,
+                                                rejectedVotes,
+                                                disputedVotes,
+                                                total,
+                                            })
+                                        }
+                                    >
+                                        <Check size={18} color={perk.limeInk} />
+                                        <Text style={styles.submitButtonText}>
+                                            {submitLabel}
+                                        </Text>
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </View>
+                    )}
+                </SafeAreaView>
+            </SafeAreaProvider>
+        </Modal>
+    );
+}
+
+export default Form34ACaptureForm;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: perk.card,
+    },
+    // Permission
+    permissionOverlay: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(13,13,13,0.85)",
+    },
+    permissionSafeArea: {flex: 1},
+    permissionContainer: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        paddingHorizontal: 16,
+    },
+    permissionCard: {
+        width: "100%",
+        maxWidth: 400,
+        backgroundColor: perk.card,
+        borderRadius: 16,
+        padding: 24,
+        alignItems: "center",
+    },
+    permissionText: {
+        fontSize: 18,
+        color: perk.ink,
+        textAlign: "center",
+        marginBottom: 24,
+        lineHeight: 24,
+    },
+    permissionButton: {
+        backgroundColor: perk.lime,
+        paddingVertical: 16,
+        paddingHorizontal: 32,
+        borderRadius: 12,
+        marginBottom: 16,
+        width: "100%",
+        alignItems: "center",
+    },
+    permissionButtonText: {
+        color: perk.limeInk,
+        fontSize: 16,
+        fontWeight: "800",
+    },
+    permissionCancelButton: {
+        paddingVertical: 16,
+        borderRadius: 12,
+        backgroundColor: perk.surface,
+        alignItems: "center",
+        width: "100%",
+    },
+    // Header
+    header: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        paddingHorizontal: 16,
+        paddingBottom: 12,
+        backgroundColor: perk.card,
+    },
+    title: {
+        fontSize: 19,
+        fontWeight: "900",
+        letterSpacing: -0.4,
+        color: perk.ink,
+    },
+    closeButton: {
+        width: 30,
+        height: 30,
+        borderRadius: 15,
+        backgroundColor: perk.surface,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    // Camera
+    cameraContainer: {flex: 1},
+    camera: {flex: 1},
+    cameraControls: {
+        position: "absolute",
+        bottom: 50,
+        left: 0,
+        right: 0,
+        alignItems: "center",
+    },
+    captureButton: {
+        width: 80,
+        height: 80,
+        borderRadius: 40,
+        backgroundColor: perk.lime,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    // Body
+    body: {flex: 1},
+    content: {flex: 1},
+    contentInner: {
+        paddingHorizontal: 16,
+        paddingTop: 4,
+        paddingBottom: 16,
+    },
+    sectionLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.8,
+        color: perk.mute,
+        marginBottom: 10,
+    },
+    cameraButton: {
+        flexDirection: "row",
+        backgroundColor: perk.ink,
+        paddingVertical: 13,
+        paddingHorizontal: 24,
+        borderRadius: 12,
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 8,
+    },
+    cameraButtonText: {
+        color: perk.lime,
+        fontSize: 13,
+        fontWeight: "800",
+    },
+    capturedRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        backgroundColor: perk.mint,
+        borderRadius: 12,
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+    },
+    capturedText: {
+        fontSize: 13,
+        color: perk.greenDeep,
+        fontWeight: "800",
+    },
+    recaptureText: {
+        color: perk.copperDeep,
+        fontSize: 13,
+        fontWeight: "800",
+        textDecorationLine: "underline",
+    },
+    voteRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        paddingVertical: 8,
+        borderTopWidth: 1,
+        borderTopColor: perk.rule08,
+    },
+    voteWho: {
+        flex: 1,
+        paddingRight: 12,
+    },
+    voteName: {
+        fontSize: 12.5,
+        fontWeight: "800",
+        color: perk.ink,
+    },
+    voteParty: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        color: perk.mute,
+        letterSpacing: 0.6,
+        marginTop: 1,
+        textTransform: "uppercase",
+    },
+    vbox: {
+        width: 52,
+        height: 34,
+        borderWidth: 1.5,
+        borderColor: perk.rule16,
+        borderRadius: 9,
+        paddingHorizontal: 4,
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 12,
+        fontWeight: "700",
+        textAlign: "center",
+        color: perk.mute2,
+        backgroundColor: perk.card,
+    },
+    vboxSet: {
+        borderColor: perk.ink,
+        color: perk.ink,
+    },
+    // Floating footer
+    footer: {
+        backgroundColor: perk.card,
+        borderWidth: 1.5,
+        borderColor: perk.ink,
+        borderRadius: 16,
+        marginHorizontal: 12,
+        marginBottom: 12,
+        paddingHorizontal: 14,
+        paddingTop: 10,
+        paddingBottom: 12,
+        shadowColor: perk.ink,
+        shadowOffset: {width: 0, height: 10},
+        shadowOpacity: 0.12,
+        shadowRadius: 18,
+        elevation: 10,
+    },
+    totalRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+    },
+    totalLabel: {
+        fontSize: 14,
+        fontWeight: "800",
+        color: perk.ink,
+    },
+    totalValue: {
+        fontSize: 20,
+        fontWeight: "900",
+        color: perk.coralDeep,
+    },
+    footerButtons: {
+        flexDirection: "row",
+        gap: 8,
+        marginTop: 10,
+    },
+    cancelButton: {
+        flex: 0.7,
+        paddingVertical: 13,
+        borderRadius: 12,
+        backgroundColor: perk.surface,
+        alignItems: "center",
+    },
+    cancelButtonText: {
+        color: perk.ink,
+        fontSize: 13,
+        fontWeight: "800",
+    },
+    submitButton: {
+        flex: 1.3,
+        flexDirection: "row",
+        paddingVertical: 13,
+        borderRadius: 12,
+        backgroundColor: perk.lime,
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 8,
+    },
+    submitButtonText: {
+        color: perk.limeInk,
+        fontSize: 13,
+        fontWeight: "800",
+    },
+    disabledButton: {
+        backgroundColor: perk.paperDeep,
+    },
+});

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/ResultsTable.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/ResultsTable.tsx
@@ -2,6 +2,7 @@ import {StyleSheet, Text, View} from "react-native";
 
 import {IPollingStationPresResults} from "@/app/types";
 import React from "react";
+import {perk} from "@/app/_utils/colors";
 
 export function ResultsTable({results}: {results: IPollingStationPresResults[]}) {
     // Sort candidates by votes in descending order
@@ -9,29 +10,9 @@ export function ResultsTable({results}: {results: IPollingStationPresResults[]})
     const totalVotes = results.reduce((sum, candidate) => sum + candidate.votes, 0);
 
     return (
-        <View
-            style={{
-                backgroundColor: "#FFFFFF",
-                borderRadius: 12,
-                shadowColor: "#000000",
-                shadowOffset: {width: 0, height: 2},
-                shadowOpacity: 0.1,
-                shadowRadius: 8,
-                elevation: 4,
-                overflow: "hidden",
-            }}
-        >
+        <View style={styles.wrapper}>
             <View style={styles.tableHeader}>
-                <Text
-                    style={{
-                        fontSize: 16,
-                        fontWeight: "bold",
-                        color: "#FFFFFF",
-                        textAlign: "center",
-                    }}
-                >
-                    Presidential Election Results
-                </Text>
+                <Text style={styles.tableTitle}>Presidential Election Results</Text>
             </View>
 
             <View style={styles.headerRow}>
@@ -122,55 +103,51 @@ export function ResultsTable({results}: {results: IPollingStationPresResults[]})
 export default ResultsTable;
 
 const styles = StyleSheet.create({
-    container: {
-        backgroundColor: "#FFFFFF",
-        borderRadius: 12,
-        shadowColor: "#000000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 8,
-        elevation: 4,
+    wrapper: {
+        backgroundColor: perk.card,
+        borderWidth: 1.5,
+        borderColor: perk.ink,
+        borderRadius: 14,
         overflow: "hidden",
-        marginVertical: 8,
     },
     tableHeader: {
-        backgroundColor: "#DC143C",
-        paddingVertical: 16,
-        paddingHorizontal: 20,
+        backgroundColor: perk.ink,
+        paddingVertical: 10,
+        paddingHorizontal: 14,
     },
     tableTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#FFFFFF",
-        textAlign: "center",
+        fontSize: 13.5,
+        fontWeight: "800",
+        letterSpacing: 0.2,
+        color: perk.lime,
     },
     headerRow: {
         flexDirection: "row",
-        backgroundColor: "#F8F9FA",
-        paddingVertical: 14,
-        paddingHorizontal: 16,
-        borderBottomWidth: 2,
-        borderBottomColor: "#E9ECEF",
+        backgroundColor: perk.surface,
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+        borderBottomWidth: 1,
+        borderBottomColor: perk.rule08,
     },
     dataRow: {
         flexDirection: "row",
-        paddingVertical: 16,
-        paddingHorizontal: 16,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
         borderBottomWidth: 1,
-        borderBottomColor: "#F1F3F4",
-        minHeight: 60,
+        borderBottomColor: perk.rule08,
+        minHeight: 56,
         alignItems: "center",
     },
     evenRow: {
-        backgroundColor: "#FFFFFF",
+        backgroundColor: perk.card,
     },
     oddRow: {
-        backgroundColor: "#FAFBFC",
+        backgroundColor: perk.paper,
     },
     winnerRow: {
-        backgroundColor: "#FFF8E1",
+        backgroundColor: "rgba(196,255,94,0.22)",
         borderLeftWidth: 4,
-        borderLeftColor: "#FF9800",
+        borderLeftColor: perk.limeDeep,
     },
     rankColumn: {
         width: 40,
@@ -193,38 +170,42 @@ const styles = StyleSheet.create({
         alignItems: "center",
     },
     headerText: {
-        fontSize: 14,
-        fontWeight: "bold",
-        color: "#495057",
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        fontWeight: "700",
+        letterSpacing: 0.6,
+        color: perk.mute,
         textAlign: "center",
     },
     cellText: {
-        fontSize: 14,
-        color: "#212529",
+        fontSize: 13,
+        color: perk.ink,
     },
     rankText: {
-        fontWeight: "600",
-        color: "#6C757D",
+        fontWeight: "800",
+        color: perk.mute,
     },
     candidateName: {
-        fontWeight: "600",
-        lineHeight: 20,
-    },
-    partyText: {
-        color: "#6C757D",
-        fontSize: 13,
+        fontWeight: "800",
         lineHeight: 18,
     },
-    voteText: {
-        fontWeight: "bold",
-        fontSize: 15,
+    partyText: {
+        fontFamily: "SpaceMono-Regular",
+        color: perk.mute,
+        fontSize: 10,
+        lineHeight: 15,
     },
-    percentText: {
-        fontWeight: "600",
-        color: "#495057",
+    voteText: {
+        fontFamily: "SpaceMono-Regular",
+        fontWeight: "700",
         fontSize: 13,
     },
+    percentText: {
+        fontWeight: "800",
+        color: perk.ink,
+        fontSize: 12,
+    },
     winnerText: {
-        color: "#DC143C",
+        color: perk.copperDeep,
     },
 });

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/ResultsTable.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/ResultsTable.tsx
@@ -4,7 +4,13 @@ import {IPollingStationPresResults} from "@/app/types";
 import React from "react";
 import {perk} from "@/app/_utils/colors";
 
-export function ResultsTable({results}: {results: IPollingStationPresResults[]}) {
+export function ResultsTable({
+    results,
+    title = "Election Results",
+}: {
+    results: IPollingStationPresResults[];
+    title?: string;
+}) {
     // Sort candidates by votes in descending order
     const sortedCandidates = [...results].sort((a, b) => b.votes - a.votes);
     const totalVotes = results.reduce((sum, candidate) => sum + candidate.votes, 0);
@@ -12,7 +18,7 @@ export function ResultsTable({results}: {results: IPollingStationPresResults[]})
     return (
         <View style={styles.wrapper}>
             <View style={styles.tableHeader}>
-                <Text style={styles.tableTitle}>Presidential Election Results</Text>
+                <Text style={styles.tableTitle}>{title}</Text>
             </View>
 
             <View style={styles.headerRow}>
@@ -62,13 +68,13 @@ export function ResultsTable({results}: {results: IPollingStationPresResults[]})
                                     isWinner && styles.winnerText,
                                 ]}
                             >
-                                {candidate.presidential_candidate.first_name}{" "}
-                                {candidate.presidential_candidate.last_name}
+                                {candidate.candidate.first_name}{" "}
+                                {candidate.candidate.last_name}
                             </Text>
                         </View>
                         <View style={styles.partyColumn}>
                             <Text style={[styles.cellText, styles.partyText]}>
-                                {candidate.presidential_candidate.party}
+                                {candidate.candidate.party}
                             </Text>
                         </View>
                         <View style={styles.votesColumn}>

--- a/NATIVE/app/(tabs)/communityNotes/[id]/_components/VoteSummary.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/_components/VoteSummary.tsx
@@ -1,6 +1,7 @@
 import {StyleSheet, Text, View} from "react-native";
 
 import React from "react";
+import {perk} from "@/app/_utils/colors";
 
 interface VoteSummaryProps {
     totalValidVotes: number;
@@ -25,77 +26,65 @@ export function VoteSummary({
         registeredVoters > 0
             ? ((totalVotesCast / registeredVoters) * 100).toFixed(1)
             : "0.0";
+
+    const rejectionRate =
+        totalVotesCast > 0
+            ? ((rejectedVotes / totalVotesCast) * 100).toFixed(2)
+            : "0.00";
+
     return (
-        <View style={styles.container}>
-            <View style={styles.header}>
-                <Text style={styles.headerTitle}>Vote Summary</Text>
+        <View style={styles.card}>
+            <Text style={styles.head}>Vote summary</Text>
+
+            <View style={styles.grid}>
+                <View style={[styles.tile, {backgroundColor: perk.mint}]}>
+                    <Text style={[styles.tileValue, {color: perk.greenDeep}]}>
+                        {totalValidVotes.toLocaleString()}
+                    </Text>
+                    <Text style={[styles.tileLabel, {color: perk.greenDeep}]}>
+                        VALID VOTES
+                    </Text>
+                </View>
+                <View style={[styles.tile, {backgroundColor: perk.coral}]}>
+                    <Text style={[styles.tileValue, {color: perk.coralDeep}]}>
+                        {rejectedVotes.toLocaleString()}
+                    </Text>
+                    <Text style={[styles.tileLabel, {color: perk.coralDeep}]}>
+                        REJECTED
+                    </Text>
+                </View>
+                <View style={[styles.tile, {backgroundColor: perk.periwinkle}]}>
+                    <Text style={[styles.tileValue, {color: perk.periwinkleDeep}]}>
+                        {disputedVotes.toLocaleString()}
+                    </Text>
+                    <Text style={[styles.tileLabel, {color: perk.periwinkleDeep}]}>
+                        DISPUTED
+                    </Text>
+                </View>
+                <View style={[styles.tile, {backgroundColor: perk.surface}]}>
+                    <Text style={[styles.tileValue, {color: perk.ink}]}>
+                        {rejectedObjectedTo.toLocaleString()}
+                    </Text>
+                    <Text style={[styles.tileLabel, {color: perk.mute}]}>
+                        REJECTED · OBJECTED
+                    </Text>
+                </View>
             </View>
 
-            <View style={styles.content}>
-                {/* Main Statistics */}
-                <View style={styles.statsGrid}>
-                    <View style={styles.statCard}>
-                        <Text style={styles.statValue}>
-                            {totalValidVotes.toLocaleString()}
-                        </Text>
-                        <Text style={styles.statLabel}>Valid Votes</Text>
-                    </View>
-
-                    <View style={styles.statCard}>
-                        <Text style={styles.statValue}>
-                            {rejectedVotes.toLocaleString()}
-                        </Text>
-                        <Text style={styles.statLabel}>Rejected Votes</Text>
-                    </View>
-
-                    <View style={styles.statCard}>
-                        <Text style={styles.statValue}>
-                            {disputedVotes.toLocaleString()}
-                        </Text>
-                        <Text style={styles.statLabel}>Disputed Votes</Text>
-                    </View>
-
-                    <View style={styles.statCard}>
-                        <Text style={styles.statValue}>
-                            {rejectedObjectedTo.toLocaleString()}
-                        </Text>
-                        <Text style={styles.statLabel}> Rejected objected to</Text>
-                    </View>
+            <View style={styles.lines}>
+                <View style={styles.line}>
+                    <Text style={styles.lineLabel}>Total votes cast</Text>
+                    <Text style={styles.lineValue}>
+                        {totalVotesCast.toLocaleString()}
+                    </Text>
                 </View>
-
-                {/* Detailed Breakdown */}
-                <View style={styles.breakdown}>
-                    <View style={styles.breakdownRow}>
-                        <Text style={styles.breakdownLabel}>Total Votes Cast:</Text>
-                        <Text style={styles.breakdownValue}>
-                            {totalVotesCast.toLocaleString()}
-                        </Text>
-                    </View>
-
-                    <View style={styles.breakdownRow}>
-                        <Text style={styles.breakdownLabel}>Voter Turnout:</Text>
-                        <Text style={styles.breakdownValue}>{turnoutPercentage}%</Text>
-                    </View>
-
-                    <View style={styles.breakdownRow}>
-                        <Text style={styles.breakdownLabel}>Rejection Rate:</Text>
-                        <Text style={styles.breakdownValue}>
-                            {totalVotesCast > 0
-                                ? ((rejectedVotes / totalVotesCast) * 100).toFixed(2)
-                                : "0.00"}
-                            %
-                        </Text>
-                    </View>
+                <View style={styles.line}>
+                    <Text style={styles.lineLabel}>Voter turnout</Text>
+                    <Text style={styles.lineValue}>{turnoutPercentage}%</Text>
                 </View>
-
-                {/* Total Summary */}
-                <View style={styles.totalSection}>
-                    <View style={styles.totalRow}>
-                        <Text style={styles.totalLabel}>Overall Total Votes Cast:</Text>
-                        <Text style={styles.totalValue}>
-                            {totalVotesCast.toLocaleString()}
-                        </Text>
-                    </View>
+                <View style={styles.line}>
+                    <Text style={styles.lineLabel}>Rejection rate</Text>
+                    <Text style={styles.lineValue}>{rejectionRate}%</Text>
                 </View>
             </View>
         </View>
@@ -105,104 +94,68 @@ export function VoteSummary({
 export default VoteSummary;
 
 const styles = StyleSheet.create({
-    container: {
-        backgroundColor: "#FFFFFF",
-        borderRadius: 12,
-        shadowColor: "#000000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 8,
-        elevation: 4,
-        marginTop: 16,
+    card: {
+        borderWidth: 1.5,
+        borderColor: perk.ink,
+        borderRadius: 14,
         overflow: "hidden",
+        marginTop: 16,
     },
-    header: {
-        backgroundColor: "#006600",
-        paddingVertical: 16,
-        paddingHorizontal: 20,
+    head: {
+        backgroundColor: perk.ink,
+        color: perk.lime,
+        fontSize: 13.5,
+        fontWeight: "800",
+        letterSpacing: 0.2,
+        paddingVertical: 9,
+        paddingHorizontal: 14,
     },
-    headerTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#FFFFFF",
-        textAlign: "center",
-    },
-    content: {
-        padding: 20,
-    },
-    statsGrid: {
+    grid: {
         flexDirection: "row",
         flexWrap: "wrap",
-        marginBottom: 20,
-        gap: 12,
+        gap: 8,
+        padding: 12,
     },
-    statCard: {
-        flex: 1,
-        minWidth: "45%",
-        backgroundColor: "#F8F9FA",
-        borderRadius: 8,
-        padding: 16,
+    tile: {
+        flexGrow: 1,
+        flexBasis: "45%",
+        borderRadius: 10,
+        paddingVertical: 10,
+        paddingHorizontal: 8,
         alignItems: "center",
-        borderLeftWidth: 4,
-        borderLeftColor: "#DC143C",
     },
-    statValue: {
-        fontSize: 24,
-        fontWeight: "bold",
-        color: "#DC143C",
-        marginBottom: 4,
+    tileValue: {
+        fontSize: 22,
+        fontWeight: "900",
+        letterSpacing: -0.4,
     },
-    statLabel: {
-        fontSize: 12,
-        color: "#6C757D",
-        textAlign: "center",
-        fontWeight: "600",
+    tileLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 8,
+        fontWeight: "700",
+        letterSpacing: 1,
+        marginTop: 3,
     },
-    breakdown: {
+    lines: {
+        paddingHorizontal: 14,
+        paddingBottom: 12,
+        paddingTop: 2,
+    },
+    line: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        paddingVertical: 7,
         borderTopWidth: 1,
-        borderTopColor: "#E9ECEF",
-        paddingTop: 16,
-        marginBottom: 16,
+        borderTopColor: perk.rule08,
     },
-    breakdownRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        paddingVertical: 8,
+    lineLabel: {
+        fontSize: 12,
+        color: perk.ink,
     },
-    breakdownLabel: {
-        fontSize: 15,
-        color: "#495057",
-        fontWeight: "500",
-    },
-    breakdownValue: {
-        fontSize: 15,
-        fontWeight: "600",
-        color: "#212529",
-    },
-    totalSection: {
-        borderTopWidth: 2,
-        borderTopColor: "#DC143C",
-        paddingTop: 16,
-        backgroundColor: "#FFF8F8",
-        marginHorizontal: -20,
-        marginBottom: -20,
-        paddingHorizontal: 20,
-        paddingBottom: 20,
-    },
-    totalRow: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-    },
-    totalLabel: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#212529",
-    },
-    totalValue: {
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "#DC143C",
+    lineValue: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 12,
+        fontWeight: "700",
+        color: perk.ink,
     },
 });

--- a/NATIVE/app/(tabs)/communityNotes/[id]/index.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/index.tsx
@@ -11,6 +11,7 @@ import {
 import {ChevronLeft, ChevronRight} from "lucide-react-native";
 import {router, useLocalSearchParams} from "expo-router";
 
+import {TLevelTabs} from "@/app/types";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
 import {perk} from "@/app/_utils/colors";
 import useAuthStore from "@/app/_utils/authStore";
@@ -64,13 +65,28 @@ const PollingStationResultsSummaryList = () => {
         }
     }, [id, userToken]);
 
-    const races = [
-        {id: "presidential", title: "President", geo: "National"},
-        {id: "governor", title: "Governor", geo: currentCenter?.county},
-        {id: "senator", title: "Senator", geo: currentCenter?.county},
-        {id: "mp", title: "MP", geo: currentCenter?.constituency},
-        {id: "woman-rep", title: "Woman Rep", geo: currentCenter?.county},
-        {id: "mca", title: "MCA", geo: `${currentCenter?.ward} Ward`},
+    const races: {id: string; title: string; geo?: string; level: TLevelTabs}[] = [
+        {id: "presidential", title: "President", geo: "National", level: "president"},
+        {
+            id: "governor",
+            title: "Governor",
+            geo: currentCenter?.county,
+            level: "governor",
+        },
+        {
+            id: "senator",
+            title: "Senator",
+            geo: currentCenter?.county,
+            level: "senator",
+        },
+        {id: "mp", title: "MP", geo: currentCenter?.constituency, level: "mp"},
+        {
+            id: "woman-rep",
+            title: "Woman Rep",
+            geo: currentCenter?.county,
+            level: "womanRep",
+        },
+        {id: "mca", title: "MCA", geo: `${currentCenter?.ward} Ward`, level: "mca"},
     ];
 
     return (
@@ -113,7 +129,7 @@ const PollingStationResultsSummaryList = () => {
                             style={[styles.raceRow, idx > 0 && styles.raceRowBorder]}
                             onPress={() => {
                                 router.navigate(
-                                    `/communityNotes/${currentStationCode}/presResults`,
+                                    `/communityNotes/${currentStationCode}/presResults?level=${race.level}`,
                                 );
                             }}
                             activeOpacity={0.8}

--- a/NATIVE/app/(tabs)/communityNotes/[id]/index.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/index.tsx
@@ -8,29 +8,24 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import {ChevronLeft, ChevronRight} from "lucide-react-native";
 import {router, useLocalSearchParams} from "expo-router";
 
-import {Ionicons} from "@expo/vector-icons";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
+import {perk} from "@/app/_utils/colors";
 import useAuthStore from "@/app/_utils/authStore";
 import useCurrentPollingStationStore from "@/app/_utils/curentStationStore";
 
 const PollingStationResultsSummaryList = () => {
     const {id} = useLocalSearchParams();
-    console.log(id, "params << PollingStationResultsSummaryList");
 
     const {
-        setStations,
-        stations,
         currentStationCode,
-        setCurrentCenter,
         setCurrentStationCode,
         currentCenter,
         setCurrentStationInfo,
         currentStationInfo,
     } = useCurrentPollingStationStore();
-
-    console.log(currentStationCode === id, "should be True for matching station code");
 
     const {userToken} = useAuthStore();
 
@@ -58,7 +53,6 @@ const PollingStationResultsSummaryList = () => {
                     },
                 );
                 const data = await response.json();
-                console.log(data, "data in PollingStationResultsSummaryList");
                 setCurrentStationInfo(data);
             } catch (error) {
                 console.error("Error fetching polling station info:", error);
@@ -70,577 +64,165 @@ const PollingStationResultsSummaryList = () => {
         }
     }, [id, userToken]);
 
-    const electionCategories = [
-        {
-            id: "presidential",
-            title: "President",
-            icon: "flag",
-            color: "#E3F2FD",
-            iconColor: "#1976D2",
-            leadingCandidate: "Pres 1",
-            percentage: "52.3%",
-            votes: "2,345",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
-        {
-            id: "governor",
-            title: "Governor",
-            icon: "business",
-            color: "#E8F5E8",
-            iconColor: "#388E3C",
-            leadingCandidate: "Gov 1",
-            percentage: "48.7%",
-            votes: "1,876",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
-        {
-            id: "senator",
-            title: "Senator",
-            icon: "medal",
-            color: "#F3E5F5",
-            iconColor: "#7B1FA2",
-            leadingCandidate: "Sen 1",
-            percentage: "55.1%",
-            votes: "1,234",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
-        {
-            id: "mp",
-            title: "MP",
-            icon: "people",
-            color: "#FFF3E0",
-            iconColor: "#F57C00",
-            leadingCandidate: "MP 3",
-            percentage: "60.4%",
-            votes: "2,012",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
-        {
-            id: "woman-rep",
-            title: "Woman Representative",
-            icon: "female",
-            color: "#FCE4EC",
-            iconColor: "#C2185B",
-            leadingCandidate: "WR 1",
-            percentage: "58.9%",
-            votes: "1,543",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
-        {
-            id: "mca",
-            title: "MCA",
-            icon: "home",
-            color: "#E0F7FA",
-            iconColor: "#0097A7",
-            leadingCandidate: "MCA 1",
-            percentage: "62.7%",
-            votes: "1,098",
-            status: "Leading",
-            statusColor: "#4CAF50",
-        },
+    const races = [
+        {id: "presidential", title: "President", geo: "National"},
+        {id: "governor", title: "Governor", geo: currentCenter?.county},
+        {id: "senator", title: "Senator", geo: currentCenter?.county},
+        {id: "mp", title: "MP", geo: currentCenter?.constituency},
+        {id: "woman-rep", title: "Woman Rep", geo: currentCenter?.county},
+        {id: "mca", title: "MCA", geo: `${currentCenter?.ward} Ward`},
     ];
 
-    const CategoryCard = ({category}) => (
-        <TouchableOpacity
-            style={[styles.categoryCard, {backgroundColor: category.color}]}
-            onPress={() => {
-                router.navigate(`/communityNotes/${currentStationCode}/presResults`);
-            }}
-            activeOpacity={0.8}
-        >
-            <View style={styles.cardHeader}>
-                <View style={styles.cardLeft}>
-                    <View
-                        style={[
-                            styles.iconContainer,
-                            {backgroundColor: "rgba(255,255,255,0.7)"},
-                        ]}
-                    >
-                        <Ionicons
-                            name={category.icon}
-                            size={24}
-                            color={category.iconColor}
-                        />
-                    </View>
-                    <View style={styles.cardInfo}>
-                        <Text style={styles.cardTitle}>{category.title} results</Text>
-                        {/* <Text style={styles.cardSubtitle}>
-                            {category.leadingCandidate}
-                        </Text> */}
-                    </View>
-                </View>
-                <View style={styles.cardRight}>
-                    {/* <View style={styles.percentageContainer}>
-                        <Text style={styles.percentage}>{category.percentage}</Text>
-                        <Text style={styles.votes}>{category.votes} votes</Text>
-                    </View> */}
-                    <Ionicons name="chevron-forward" size={20} color="#666" />
-                </View>
-            </View>
-            {/* <View style={styles.statusContainer}>
-                <View
-                    style={[
-                        styles.statusBadge,
-                        {backgroundColor: category.statusColor + "20"},
-                    ]}
-                >
-                    <Text style={[styles.statusText, {color: category.statusColor}]}>
-                        {category.status}
-                    </Text>
-                </View>
-            </View> */}
-        </TouchableOpacity>
-    );
-
     return (
-        <SafeAreaView
-            style={{
-                flex: 1,
-                backgroundColor: "#F5F5F5",
-                paddingTop: 16,
-            }}
-        >
+        <SafeAreaView style={styles.screen}>
+            <StatusBar barStyle="dark-content" backgroundColor={perk.card} />
+
             <ScrollView
-                style={{
-                    flex: 1,
-                    paddingHorizontal: 20,
-                }}
+                style={styles.scroll}
+                contentContainerStyle={styles.content}
                 showsVerticalScrollIndicator={false}
             >
-                {/* Polling Station Info */}
-                <View
-                    style={{
-                        backgroundColor: "#fff",
-                        borderRadius: 16,
-                        padding: 20,
-                        marginBottom: 16,
-                        elevation: 2,
-                        shadowColor: "#000",
-                        shadowOffset: {width: 0, height: 2},
-                        shadowOpacity: 0.1,
-                        shadowRadius: 4,
-                    }}
-                >
-                    <View style={styles.stationHeader}>
-                        <Ionicons name="location" size={20} color="#666" />
-                        <Text
-                            style={{
-                                fontSize: 20,
-                                fontWeight: "bold",
-                                color: "black",
-                                marginLeft: 8,
-                            }}
-                        >
-                            {currentStationInfo?.polling_center}
-                        </Text>
-                    </View>
-                    <Text
-                        style={{
-                            fontSize: 16,
-                            color: "#666",
-                            marginBottom: 16,
-                            marginTop: 4,
-                        }}
+                {/* Header */}
+                <View style={styles.top}>
+                    <TouchableOpacity
+                        style={styles.back}
+                        onPress={() => router.back()}
+                        activeOpacity={0.8}
                     >
-                        Station Code: {currentStationInfo?.code}
-                    </Text>
-                    <View style={styles.stationStats}>
-                        <View style={styles.statItem}>
-                            <Text style={styles.statValue}>
-                                {currentStationInfo?.registered_voters}
-                            </Text>
-                            <Text style={styles.statLabel}>Total Voters</Text>
-                        </View>
-                        <View style={styles.statItem}>
-                            <Text style={styles.statValue}>
-                                {currentStationInfo?.stream_number}
-                            </Text>
-                            <Text style={styles.statLabel}>Stream Number</Text>
-                        </View>
-                    </View>
+                        <ChevronLeft size={16} color={perk.ink} />
+                    </TouchableOpacity>
+                    <Text style={styles.topLabel}>POLLING STATION RESULTS</Text>
                 </View>
 
-                {/* Election Categories */}
-                <Text style={styles.sectionTitle}>Election Results</Text>
-                {electionCategories.map((category) => (
-                    <CategoryCard key={category.id} category={category} />
-                ))}
+                {/* Station */}
+                <Text style={styles.stationName}>
+                    {currentStationInfo?.polling_center}
+                </Text>
+                <Text style={styles.stationMeta}>
+                    Stream {currentStationInfo?.stream_number} ·{" "}
+                    {currentStationInfo?.code} · {currentStationInfo?.registered_voters}{" "}
+                    voters
+                </Text>
+
+                {/* Races */}
+                <Text style={styles.sectionLabel}>ELECTION RESULTS</Text>
+                <View style={styles.raceList}>
+                    {races.map((race, idx) => (
+                        <TouchableOpacity
+                            key={race.id}
+                            style={[styles.raceRow, idx > 0 && styles.raceRowBorder]}
+                            onPress={() => {
+                                router.navigate(
+                                    `/communityNotes/${currentStationCode}/presResults`,
+                                );
+                            }}
+                            activeOpacity={0.8}
+                        >
+                            <View style={styles.raceText}>
+                                <Text style={styles.raceName}>{race.title}</Text>
+                                <Text style={styles.raceGeo}>{race.geo}</Text>
+                            </View>
+                            <ChevronRight size={15} color={perk.copperDeep} />
+                        </TouchableOpacity>
+                    ))}
+                </View>
             </ScrollView>
         </SafeAreaView>
     );
 };
 
+export default PollingStationResultsSummaryList;
+
 const styles = StyleSheet.create({
-    container: {
+    screen: {
         flex: 1,
-        backgroundColor: "#F5F5F5",
+        backgroundColor: perk.card,
         paddingTop: StatusBar.currentHeight || 0,
     },
-    header: {
-        backgroundColor: "#fff",
-        paddingHorizontal: 20,
-        paddingVertical: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
-    },
-    userGreeting: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-    },
-    avatar: {
-        width: 40,
-        height: 40,
-        borderRadius: 20,
-        backgroundColor: "#2196F3",
-        alignItems: "center",
-        justifyContent: "center",
-    },
-    greetingText: {
+    scroll: {
         flex: 1,
-        fontSize: 16,
-        fontWeight: "600",
-        color: "#333",
-        marginLeft: 12,
     },
-    content: {},
-    stationInfo: {},
-    stationHeader: {
+    content: {
+        paddingHorizontal: 20,
+        paddingTop: 12,
+        paddingBottom: 40,
+    },
+    top: {
         flexDirection: "row",
         alignItems: "center",
-        marginBottom: 8,
-    },
-    stationName: {},
-    stationLocation: {},
-    stationStats: {
-        flexDirection: "row",
-        justifyContent: "space-around",
-    },
-    statItem: {
-        alignItems: "center",
-    },
-    statValue: {
-        fontSize: 24,
-        fontWeight: "bold",
-        color: "#2196F3",
-    },
-    statLabel: {
-        fontSize: 12,
-        color: "#666",
-        marginTop: 4,
-    },
-    sectionTitle: {
-        fontSize: 22,
-        fontWeight: "bold",
-        color: "#333",
-        marginBottom: 16,
-    },
-    categoryCard: {
-        borderRadius: 16,
-        padding: 16,
-        marginBottom: 16,
-        elevation: 2,
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-    },
-    cardHeader: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
+        gap: 8,
         marginBottom: 12,
     },
-    cardLeft: {
-        flexDirection: "row",
-        alignItems: "center",
-        flex: 1,
-    },
-    iconContainer: {
-        width: 48,
-        height: 48,
-        borderRadius: 12,
+    back: {
+        width: 30,
+        height: 30,
+        borderRadius: 15,
+        backgroundColor: perk.surface,
         alignItems: "center",
         justifyContent: "center",
-        marginRight: 12,
     },
-    cardInfo: {
-        flex: 1,
-    },
-    cardTitle: {
-        fontSize: 18,
-        fontWeight: "600",
-        color: "#333",
-    },
-    cardSubtitle: {
-        fontSize: 14,
-        color: "#666",
-        marginTop: 2,
-    },
-    cardRight: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    percentageContainer: {
-        alignItems: "flex-end",
-        marginRight: 8,
-    },
-    percentage: {
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    votes: {
-        fontSize: 12,
-        color: "#666",
-    },
-    statusContainer: {
-        alignItems: "flex-start",
-    },
-    statusBadge: {
-        paddingHorizontal: 12,
-        paddingVertical: 4,
-        borderRadius: 12,
-    },
-    statusText: {
-        fontSize: 12,
-        fontWeight: "600",
-    },
-    detailHeader: {
-        backgroundColor: "#fff",
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-        paddingHorizontal: 20,
-        paddingVertical: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: "#E0E0E0",
-    },
-    backButton: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    backText: {
-        fontSize: 16,
-        color: "#2196F3",
-        marginLeft: 4,
-    },
-    detailTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    centerCard: {
-        backgroundColor: "#fff",
-        borderRadius: 16,
-        padding: 20,
-        marginBottom: 20,
-        elevation: 2,
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-    },
-    centerHeader: {
-        flexDirection: "row",
-        alignItems: "center",
-        marginBottom: 16,
-    },
-    centerIconContainer: {
-        width: 48,
-        height: 48,
-        borderRadius: 12,
-        backgroundColor: "#E3F2FD",
-        alignItems: "center",
-        justifyContent: "center",
-        marginRight: 12,
-    },
-    centerInfo: {
-        flex: 1,
-    },
-    centerName: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    centerLocation: {
-        fontSize: 14,
-        color: "#666",
-        marginTop: 2,
-    },
-    centerStats: {
-        flexDirection: "row",
-        justifyContent: "space-around",
-        marginBottom: 20,
-        paddingVertical: 16,
-        borderTopWidth: 1,
-        borderBottomWidth: 1,
-        borderColor: "#F0F0F0",
-    },
-    stationsContainer: {
-        marginTop: 4,
-    },
-    stationsTitle: {
-        fontSize: 16,
-        fontWeight: "600",
-        color: "#333",
-        marginBottom: 12,
-    },
-    stationCard: {
-        backgroundColor: "#F8F9FA",
-        borderRadius: 12,
-        padding: 16,
-        marginBottom: 8,
-        borderWidth: 1,
-        borderColor: "#E0E0E0",
-    },
-    stationCardContent: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-    },
-    stationLeft: {
-        flex: 1,
+    topLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.6,
+        color: perk.mute,
     },
     stationName: {
-        fontSize: 16,
-        fontWeight: "600",
-        color: "#333",
+        fontSize: 17,
+        fontWeight: "900",
+        letterSpacing: -0.2,
+        textTransform: "uppercase",
+        color: perk.ink,
     },
-    stationVoters: {
-        fontSize: 12,
-        color: "#666",
-        marginTop: 2,
-    },
-    stationRight: {
-        alignItems: "flex-end",
-        marginRight: 12,
-    },
-    stationTurnout: {
-        fontSize: 16,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    statusIndicator: {
-        paddingHorizontal: 8,
-        paddingVertical: 4,
-        borderRadius: 8,
-        marginTop: 4,
-    },
-    statusText: {
+    stationMeta: {
+        fontFamily: "SpaceMono-Regular",
         fontSize: 10,
-        fontWeight: "600",
-        color: "#fff",
+        color: perk.mute,
+        letterSpacing: 0.6,
+        marginTop: 3,
     },
-    headerTitle: {
-        fontSize: 18,
-        fontWeight: "bold",
-        color: "#333",
+    sectionLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.8,
+        color: perk.ink,
+        marginTop: 18,
+        marginBottom: 8,
     },
-    detailContent: {
-        flex: 1,
-        paddingHorizontal: 20,
-    },
-    summaryCard: {
-        backgroundColor: "#fff",
-        borderRadius: 16,
-        padding: 20,
-        marginVertical: 16,
-        elevation: 2,
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-    },
-    summaryHeader: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-    },
-    summaryIcon: {
-        width: 60,
-        height: 60,
-        borderRadius: 16,
-        alignItems: "center",
-        justifyContent: "center",
-    },
-    summaryStats: {
-        alignItems: "flex-end",
-    },
-    totalVotes: {
-        fontSize: 28,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    totalVotesLabel: {
-        fontSize: 14,
-        color: "#666",
-        marginTop: 4,
-    },
-    candidatesContainer: {
-        marginBottom: 20,
-    },
-    candidateCard: {
-        backgroundColor: "#fff",
-        borderRadius: 16,
-        padding: 16,
-        marginBottom: 12,
-        elevation: 2,
-        shadowColor: "#000",
-        shadowOffset: {width: 0, height: 2},
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-    },
-    candidateHeader: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "flex-start",
-        marginBottom: 12,
-    },
-    candidateInfo: {
-        flex: 1,
-    },
-    candidateName: {
-        fontSize: 18,
-        fontWeight: "600",
-        color: "#333",
-    },
-    candidateParty: {
-        fontSize: 14,
-        color: "#666",
-        marginTop: 2,
-    },
-    candidateStats: {
-        alignItems: "flex-end",
-    },
-    candidatePercentage: {
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "#333",
-    },
-    candidateVotes: {
-        fontSize: 12,
-        color: "#666",
-        marginTop: 2,
-    },
-    progressContainer: {
-        marginTop: 8,
-    },
-    progressBar: {
-        height: 8,
-        backgroundColor: "#E0E0E0",
-        borderRadius: 4,
+    raceList: {
+        borderRadius: 14,
         overflow: "hidden",
+        backgroundColor: perk.surface,
     },
-    progressFill: {
-        height: "100%",
-        borderRadius: 4,
+    raceRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 10,
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+    },
+    raceRowBorder: {
+        borderTopWidth: 1,
+        borderTopColor: perk.rule08,
+    },
+    raceText: {
+        flex: 1,
+        minWidth: 0,
+    },
+    raceName: {
+        fontSize: 13,
+        fontWeight: "800",
+        letterSpacing: -0.2,
+        color: perk.ink,
+    },
+    raceGeo: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 8,
+        color: perk.mute,
+        letterSpacing: 1,
+        marginTop: 2,
+        textTransform: "uppercase",
     },
 });
-
-export default PollingStationResultsSummaryList;

--- a/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
@@ -16,6 +16,7 @@ import {ResultsTable} from "./_components/ResultsTable";
 import {VoteSummary} from "./_components/VoteSummary";
 import {ZoomableImage} from "./_components/ZoomableImage";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
+import {perk} from "@/app/_utils/colors";
 import {sampleElectionData} from "../_sampleData";
 import useAuthStore from "@/app/_utils/authStore";
 import useCurrentPollingStationStore from "@/app/_utils/curentStationStore";
@@ -108,54 +109,16 @@ export default function ResultsScreen() {
             />
 
             <ScrollView showsVerticalScrollIndicator={false}>
-                <View
-                    style={{
-                        padding: 10,
-                        backgroundColor: "#FFFFFF",
-                        borderBottomWidth: 1,
-                        borderBottomColor: "#E9ECEF",
-                        shadowColor: "#000000",
-                        shadowOffset: {width: 0, height: 2},
-                        shadowOpacity: 0.05,
-                        shadowRadius: 4,
-                        elevation: 2,
-                    }}
-                >
-                    <Text
-                        style={{
-                            fontSize: 20,
-                            fontWeight: "bold",
-                            color: "#212529",
-                            textAlign: "center",
-                        }}
-                    >
+                <View style={styles.stationHeader}>
+                    <Text style={styles.stationHeaderLabel}>
+                        PRESIDENTIAL · THIS STATION
+                    </Text>
+                    <Text style={styles.stationName}>
                         {currentStationInfo?.polling_center}
                     </Text>
-                    <View
-                        style={{
-                            flexDirection: "row",
-                            justifyContent: "space-evenly",
-                            paddingTop: 8,
-                        }}
-                    >
-                        <Text style={styles.subtitle}>
-                            Stream No: {currentStationInfo?.stream_number}
-                        </Text>
-                        <Text style={styles.subtitle}>
-                            Code: {currentStationInfo?.code}
-                        </Text>
-                    </View>
-
-                    <Text
-                        style={{
-                            fontSize: 14,
-                            color: "#495057",
-                            textAlign: "center",
-                            paddingTop: 2,
-                        }}
-                    >
-                        {currentCenter?.county} / {currentCenter?.constituency} /{" "}
-                        {currentCenter?.ward}
+                    <Text style={styles.stationMeta}>
+                        Stream {currentStationInfo?.stream_number} ·{" "}
+                        {currentStationInfo?.code} · {currentCenter?.constituency}
                     </Text>
                 </View>
 
@@ -263,7 +226,7 @@ export default function ResultsScreen() {
                             onPress={() => setUpvoted(!upvoted)}
                             activeOpacity={0.8}
                         >
-                            <ThumbsUp size={24} color="#FFFFFF" />
+                            <ThumbsUp size={22} color={perk.limeInk} />
                         </TouchableOpacity>
 
                         <TouchableOpacity
@@ -299,11 +262,35 @@ const styles = StyleSheet.create({
     },
     header: {},
     title: {},
-    subtitle: {
+    stationHeader: {
+        paddingHorizontal: 16,
+        paddingTop: 12,
+        paddingBottom: 12,
+        backgroundColor: perk.card,
+        borderBottomWidth: 1,
+        borderBottomColor: perk.rule08,
+    },
+    stationHeaderLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9.5,
+        fontWeight: "700",
+        letterSpacing: 1.6,
+        color: perk.mute,
+    },
+    stationName: {
         fontSize: 16,
-        color: "#6C757D",
-        textAlign: "center",
-        fontWeight: "500",
+        fontWeight: "900",
+        letterSpacing: -0.2,
+        textTransform: "uppercase",
+        color: perk.ink,
+        marginTop: 4,
+    },
+    stationMeta: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        color: perk.mute,
+        letterSpacing: 0.6,
+        marginTop: 3,
     },
     section: {
         paddingHorizontal: 16,
@@ -342,15 +329,15 @@ const styles = StyleSheet.create({
         elevation: 8,
     },
     upvoteFab: {
-        backgroundColor: "#006600",
+        backgroundColor: perk.lime,
     },
     upvotedFab: {
-        backgroundColor: "#006600",
+        backgroundColor: perk.limeDeep,
     },
     commentFab: {
-        backgroundColor: "#B71C1C",
+        backgroundColor: perk.coralDeep,
     },
     addFab: {
-        backgroundColor: "#1976D2",
+        backgroundColor: perk.ink,
     },
 });

--- a/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
@@ -6,7 +6,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
-import {MessageCircle, PlusCircleIcon, ThumbsUp} from "lucide-react-native";
+import {MessageCircle, Plus, ThumbsUp} from "lucide-react-native";
 import React, {useEffect, useState} from "react";
 
 import {AddFormModal} from "./_components/AddFormModal";
@@ -185,14 +185,6 @@ export default function ResultsScreen() {
                                 No {levelLabel} tally has been submitted for this
                                 station yet.
                             </Text>
-                            <TouchableOpacity
-                                style={styles.emptyCta}
-                                onPress={() => setAddModalVisible(true)}
-                                activeOpacity={0.85}
-                            >
-                                <PlusCircleIcon size={16} color={perk.limeInk} />
-                                <Text style={styles.emptyCtaText}>Add results</Text>
-                            </TouchableOpacity>
                         </View>
                     )}
                 </View>
@@ -234,9 +226,9 @@ export default function ResultsScreen() {
                     <TouchableOpacity
                         style={[styles.fab, styles.addFab]}
                         onPress={() => setAddModalVisible(true)}
-                        activeOpacity={0.8}
+                        activeOpacity={0.85}
                     >
-                        <PlusCircleIcon size={24} color="#FFFFFF" />
+                        <Plus size={26} color={perk.limeInk} strokeWidth={2.6} />
                     </TouchableOpacity>
                 )}
             </View>
@@ -314,21 +306,6 @@ const styles = StyleSheet.create({
         marginTop: 6,
         maxWidth: 260,
     },
-    emptyCta: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: 8,
-        backgroundColor: perk.lime,
-        paddingVertical: 11,
-        paddingHorizontal: 20,
-        borderRadius: 12,
-        marginTop: 18,
-    },
-    emptyCtaText: {
-        fontSize: 13,
-        fontWeight: "800",
-        color: perk.limeInk,
-    },
     section: {
         paddingHorizontal: 16,
         paddingVertical: 8,
@@ -354,15 +331,15 @@ const styles = StyleSheet.create({
     },
     fabContainer: {},
     fab: {
-        width: 60,
-        height: 60,
-        borderRadius: 30,
+        width: 58,
+        height: 58,
+        borderRadius: 29,
         justifyContent: "center",
         alignItems: "center",
-        shadowColor: "#000000",
-        shadowOffset: {width: 0, height: 4},
-        shadowOpacity: 0.3,
-        shadowRadius: 8,
+        shadowColor: perk.ink,
+        shadowOffset: {width: 0, height: 8},
+        shadowOpacity: 0.22,
+        shadowRadius: 14,
         elevation: 8,
     },
     upvoteFab: {
@@ -375,6 +352,8 @@ const styles = StyleSheet.create({
         backgroundColor: perk.coralDeep,
     },
     addFab: {
-        backgroundColor: perk.ink,
+        backgroundColor: perk.lime,
+        shadowColor: perk.limeDeep,
+        shadowOpacity: 0.5,
     },
 });

--- a/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/[id]/presResults.tsx
@@ -13,6 +13,7 @@ import {AddFormModal} from "./_components/AddFormModal";
 import {CounterEvidenceModal} from "./_components/CounterEvidenceModal";
 import {IPollingStationPresResults} from "@/app/types";
 import {ResultsTable} from "./_components/ResultsTable";
+import {TLevelTabs} from "@/app/types";
 import {VoteSummary} from "./_components/VoteSummary";
 import {ZoomableImage} from "./_components/ZoomableImage";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
@@ -20,8 +21,18 @@ import {perk} from "@/app/_utils/colors";
 import {sampleElectionData} from "../_sampleData";
 import useAuthStore from "@/app/_utils/authStore";
 import useCurrentPollingStationStore from "@/app/_utils/curentStationStore";
+import {useLocalSearchParams} from "expo-router";
 
 const windowHeight = Dimensions.get("window").height;
+
+const LEVEL_LABELS: Record<TLevelTabs, string> = {
+    president: "Presidential",
+    governor: "Governor",
+    senator: "Senator",
+    womanRep: "Woman Rep",
+    mp: "MP",
+    mca: "MCA",
+};
 
 export interface IPollingStationExtraData {
     added_by: number;
@@ -56,6 +67,13 @@ export default function ResultsScreen() {
 
     const {userToken} = useAuthStore();
 
+    const {level: levelParam} = useLocalSearchParams<{level?: string}>();
+    const level: TLevelTabs =
+        levelParam && levelParam in LEVEL_LABELS
+            ? (levelParam as TLevelTabs)
+            : "president";
+    const levelLabel = LEVEL_LABELS[level];
+
     useEffect(() => {
         if (!currentStationCode) {
             return;
@@ -68,7 +86,7 @@ export default function ResultsScreen() {
         const fetchStationResults = async () => {
             try {
                 const response = await fetch(
-                    `${apiBaseURL}/api/results/polling-station/${currentStationCode}/presidential/`,
+                    `${apiBaseURL}/api/results/polling-station/${currentStationCode}/results/${level}/`,
                     {
                         headers: {
                             Authorization: `Token ${userToken}`,
@@ -89,18 +107,19 @@ export default function ResultsScreen() {
         if (currentStationCode && userToken) {
             fetchStationResults();
         }
-    }, [currentStationCode, userToken, addModalVisible]);
+    }, [currentStationCode, userToken, addModalVisible, level]);
 
     return (
         <View
             style={{
                 flex: 1,
+                backgroundColor: perk.card,
             }}
         >
             <AddFormModal
                 visible={addModalVisible}
                 onClose={() => setAddModalVisible(false)}
-                level="president"
+                level={level}
             />
             <CounterEvidenceModal
                 visible={modalVisible}
@@ -111,7 +130,7 @@ export default function ResultsScreen() {
             <ScrollView showsVerticalScrollIndicator={false}>
                 <View style={styles.stationHeader}>
                     <Text style={styles.stationHeaderLabel}>
-                        PRESIDENTIAL · THIS STATION
+                        {levelLabel.toUpperCase()} · THIS STATION
                     </Text>
                     <Text style={styles.stationName}>
                         {currentStationInfo?.polling_center}
@@ -123,44 +142,12 @@ export default function ResultsScreen() {
                 </View>
 
                 {/* Form 34A Image */}
-                {extraData && extraData.form_34A ? (
-                    <View
-                        style={{
-                            paddingHorizontal: 8,
-                        }}
-                    >
-                        <Text
-                            style={{
-                                fontSize: 14,
-                                fontWeight: "bold",
-                                color: "#212529",
-                                textAlign: "center",
-                                // marginBottom: 12,
-                                // paddingHorizontal: 4,
-                            }}
-                        >
-                            Original Form 34A
-                        </Text>
-                        <View
-                            style={{
-                                height: 0.5 * windowHeight,
-                            }}
-                        >
+                {extraData && extraData.form_34A && (
+                    <View style={{paddingHorizontal: 8}}>
+                        <Text style={styles.formLabel}>Original Form 34A</Text>
+                        <View style={{height: 0.5 * windowHeight}}>
                             <ZoomableImage uri={extraData.form_34A} />
                         </View>
-                    </View>
-                ) : (
-                    <View
-                        style={{
-                            padding: 16,
-                            alignItems: "center",
-                            justifyContent: "center",
-                            height: 0.2 * windowHeight,
-                        }}
-                    >
-                        <Text style={{textAlign: "center"}}>
-                            No Form 34A image available for this polling station.
-                        </Text>
                     </View>
                 )}
 
@@ -175,7 +162,10 @@ export default function ResultsScreen() {
                 >
                     {results && results.length > 0 ? (
                         <>
-                            <ResultsTable results={results} />
+                            <ResultsTable
+                                results={results}
+                                title={`${levelLabel} Election Results`}
+                            />
                             {extraData && (
                                 <VoteSummary
                                     totalValidVotes={extraData.valid_votes_cast}
@@ -189,17 +179,20 @@ export default function ResultsScreen() {
                             )}
                         </>
                     ) : (
-                        <View
-                            style={{
-                                padding: 16,
-                                alignItems: "center",
-                                justifyContent: "center",
-                                height: 0.2 * windowHeight,
-                            }}
-                        >
-                            <Text style={{textAlign: "center"}}>
-                                No results available for this polling station.
+                        <View style={styles.emptyState}>
+                            <Text style={styles.emptyTitle}>No results yet</Text>
+                            <Text style={styles.emptyBody}>
+                                No {levelLabel} tally has been submitted for this
+                                station yet.
                             </Text>
+                            <TouchableOpacity
+                                style={styles.emptyCta}
+                                onPress={() => setAddModalVisible(true)}
+                                activeOpacity={0.85}
+                            >
+                                <PlusCircleIcon size={16} color={perk.limeInk} />
+                                <Text style={styles.emptyCtaText}>Add results</Text>
+                            </TouchableOpacity>
                         </View>
                     )}
                 </View>
@@ -291,6 +284,50 @@ const styles = StyleSheet.create({
         color: perk.mute,
         letterSpacing: 0.6,
         marginTop: 3,
+    },
+    formLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.6,
+        color: perk.mute,
+        textAlign: "center",
+        marginBottom: 6,
+    },
+    emptyState: {
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 32,
+        paddingVertical: 48,
+    },
+    emptyTitle: {
+        fontSize: 18,
+        fontWeight: "900",
+        letterSpacing: -0.3,
+        color: perk.ink,
+    },
+    emptyBody: {
+        fontSize: 13.5,
+        color: perk.mute,
+        textAlign: "center",
+        lineHeight: 19,
+        marginTop: 6,
+        maxWidth: 260,
+    },
+    emptyCta: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 8,
+        backgroundColor: perk.lime,
+        paddingVertical: 11,
+        paddingHorizontal: 20,
+        borderRadius: 12,
+        marginTop: 18,
+    },
+    emptyCtaText: {
+        fontSize: 13,
+        fontWeight: "800",
+        color: perk.limeInk,
     },
     section: {
         paddingHorizontal: 16,

--- a/NATIVE/app/(tabs)/communityNotes/index.tsx
+++ b/NATIVE/app/(tabs)/communityNotes/index.tsx
@@ -3,13 +3,15 @@ import {
     SafeAreaView,
     ScrollView,
     StatusBar,
+    StyleSheet,
     Text,
     TouchableOpacity,
     View,
 } from "react-native";
 
-import {Ionicons} from "@expo/vector-icons";
+import {ChevronRight} from "lucide-react-native";
 import {apiBaseURL} from "@/app/_utils/apiBaseURL";
+import {perk} from "@/app/_utils/colors";
 import {router} from "expo-router";
 import useAuthStore from "@/app/_utils/authStore";
 import useCurrentPollingStationStore from "@/app/_utils/curentStationStore";
@@ -72,232 +74,250 @@ const ElectionResultsApp = () => {
             });
     }, [userToken]);
 
+    const totalVoters = stations?.reduce(
+        (acc, station) => acc + station.registered_voters,
+        0,
+    );
+
     return (
-        <SafeAreaView
-            style={{
-                flex: 1,
-                backgroundColor: "#F5F5F5",
-                paddingTop: StatusBar.currentHeight || 0,
-            }}
-        >
-            <StatusBar barStyle="dark-content" backgroundColor="#fff" />
+        <SafeAreaView style={styles.screen}>
+            <StatusBar barStyle="dark-content" backgroundColor={perk.card} />
 
             <ScrollView
-                style={{
-                    flex: 1,
-                    paddingHorizontal: 20,
-                }}
+                style={styles.scroll}
+                contentContainerStyle={styles.content}
                 showsVerticalScrollIndicator={false}
             >
-                <View
-                    key={pollingCenterInfo?.code}
-                    style={{
-                        backgroundColor: "#fff",
-                        borderRadius: 16,
-                        padding: 20,
-                        marginBottom: 20,
-                        elevation: 2,
-                        shadowColor: "#000",
-                        shadowOffset: {width: 0, height: 2},
-                        shadowOpacity: 0.1,
-                        shadowRadius: 4,
-                    }}
-                >
-                    <View
-                        style={{
-                            flexDirection: "row",
-                            alignItems: "center",
-                            marginBottom: 16,
-                        }}
-                    >
-                        <View
-                            style={{
-                                width: 48,
-                                height: 48,
-                                borderRadius: 12,
-                                backgroundColor: "#E3F2FD",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                marginRight: 12,
-                            }}
-                        >
-                            <Ionicons name="home" size={24} color="#2196F3" />
-                        </View>
-                        <View style={{flex: 1}}>
-                            <Text
-                                style={{
-                                    fontSize: 18,
-                                    fontWeight: "bold",
-                                    color: "#333",
-                                }}
-                            >
-                                {pollingCenterInfo?.name}
-                            </Text>
-                            <Text
-                                style={{
-                                    fontSize: 14,
-                                    color: "#666",
-                                    marginTop: 2,
-                                }}
-                            >
-                                {pollingCenterInfo?.county} /{" "}
-                                {pollingCenterInfo?.constituency} /{" "}
-                                {pollingCenterInfo?.ward} Ward
-                            </Text>
-                        </View>
-                    </View>
+                {/* Centre card */}
+                <View key={pollingCenterInfo?.code} style={styles.centreCard}>
+                    <Text style={styles.centreName}>{pollingCenterInfo?.name}</Text>
+                    <Text style={styles.centreMeta}>
+                        {pollingCenterInfo?.county} · {pollingCenterInfo?.constituency}{" "}
+                        · {pollingCenterInfo?.ward} Ward
+                    </Text>
 
-                    <View
-                        style={{
-                            flexDirection: "row",
-                            justifyContent: "space-around",
-                            marginBottom: 20,
-                            paddingVertical: 16,
-                            borderTopWidth: 1,
-                            borderBottomWidth: 1,
-                            borderColor: "#F0F0F0",
-                        }}
-                    >
-                        <View style={{alignItems: "center"}}>
-                            <Text
-                                style={{
-                                    fontSize: 24,
-                                    fontWeight: "bold",
-                                    color: "#2196F3",
-                                }}
-                            >
+                    <View style={styles.centreStats}>
+                        <View style={styles.centreStat}>
+                            <Text style={styles.centreStatValue}>
                                 {stations?.length.toLocaleString()}
                             </Text>
-                            <Text
-                                style={{
-                                    fontSize: 12,
-                                    color: "#666",
-                                    marginTop: 4,
-                                }}
-                            >
-                                Stations
-                            </Text>
+                            <Text style={styles.centreStatLabel}>STATIONS</Text>
                         </View>
-                        <View style={{alignItems: "center"}}>
-                            <Text
-                                style={{
-                                    fontSize: 24,
-                                    fontWeight: "bold",
-                                    color: "#2196F3",
-                                }}
-                            >
-                                {stations
-                                    ?.reduce(
-                                        (acc, station) =>
-                                            acc + station.registered_voters,
-                                        0,
-                                    )
-                                    .toLocaleString()}
+                        <View style={styles.centreStat}>
+                            <Text style={styles.centreStatValue}>
+                                {totalVoters?.toLocaleString()}
                             </Text>
-                            <Text
-                                style={{
-                                    fontSize: 12,
-                                    color: "#666",
-                                    marginTop: 4,
-                                }}
-                            >
-                                Total Voters
-                            </Text>
+                            <Text style={styles.centreStatLabel}>TOTAL VOTERS</Text>
                         </View>
-                    </View>
-
-                    <View style={{marginTop: 4}}>
-                        <Text
-                            style={{
-                                fontSize: 16,
-                                fontWeight: "600",
-                                color: "#333",
-                                marginBottom: 12,
-                            }}
-                        >
-                            Polling Stations
-                        </Text>
-                        {stations &&
-                            stations.map((station) => (
-                                <TouchableOpacity
-                                    key={station.code}
-                                    style={{
-                                        backgroundColor: "#fff",
-                                        borderRadius: 16,
-                                        paddingVertical: 18,
-                                        paddingHorizontal: 20,
-                                        marginBottom: 12,
-                                        borderWidth: 0,
-                                        shadowColor: "#000",
-                                        shadowOffset: {width: 0, height: 2},
-                                        shadowOpacity: 0.07,
-                                        shadowRadius: 8,
-                                        elevation: 2,
-                                        flexDirection: "row",
-                                        alignItems: "center",
-                                        gap: 16,
-                                    }}
-                                    onPress={() => {
-                                        router.navigate(
-                                            `/communityNotes/${station.code}`,
-                                        );
-                                        setCurrentStationCode(station.code);
-                                    }}
-                                    activeOpacity={0.92}
-                                >
-                                    {/* <View
-                                        style={{
-                                            backgroundColor: "#E3F2FD",
-                                            borderRadius: 10,
-                                            width: 44,
-                                            height: 44,
-                                            alignItems: "center",
-                                            justifyContent: "center",
-                                        }}
-                                    >
-                                        <Ionicons
-                                            name="location-outline"
-                                            size={22}
-                                            color="#2196F3"
-                                        />
-                                    </View> */}
-                                    <View style={{flex: 1}}>
-                                        <Text
-                                            style={{
-                                                fontSize: 14,
-                                                fontFamily: "Sora-Regular",
-                                                fontWeight: "600",
-                                                color: "#222",
-                                                letterSpacing: 0.2,
-                                            }}
-                                        >
-                                            {station.code} - (Stream{" "}
-                                            {station.stream_number})
-                                        </Text>
-                                        <Text
-                                            style={{
-                                                fontSize: 16,
-                                                fontFamily: "Sora-Regular",
-                                                color: "#6B7280",
-                                                marginTop: 3,
-                                            }}
-                                        >
-                                            {station.registered_voters.toLocaleString()}{" "}
-                                            voters
-                                        </Text>
-                                    </View>
-                                    <Ionicons
-                                        name="chevron-forward"
-                                        size={22}
-                                        color="red"
-                                    />
-                                </TouchableOpacity>
-                            ))}
                     </View>
                 </View>
+
+                {/* Polling stations */}
+                <Text style={styles.sectionLabel}>POLLING STATIONS</Text>
+                {stations &&
+                    stations.map((station) => {
+                        const lead = station.stream_number === 1;
+                        return (
+                            <TouchableOpacity
+                                key={station.code}
+                                style={[styles.streamRow, lead && styles.streamRowLead]}
+                                onPress={() => {
+                                    router.navigate(`/communityNotes/${station.code}`);
+                                    setCurrentStationCode(station.code);
+                                }}
+                                activeOpacity={0.9}
+                            >
+                                <View
+                                    style={[
+                                        styles.streamNum,
+                                        lead && styles.streamNumLead,
+                                    ]}
+                                >
+                                    <Text
+                                        style={[
+                                            styles.streamNumValue,
+                                            lead && styles.streamNumValueLead,
+                                        ]}
+                                    >
+                                        {station.stream_number}
+                                    </Text>
+                                    <Text
+                                        style={[
+                                            styles.streamNumLabel,
+                                            lead && styles.streamNumLabelLead,
+                                        ]}
+                                    >
+                                        STRM
+                                    </Text>
+                                </View>
+                                <View style={styles.streamText}>
+                                    <Text style={styles.streamName}>
+                                        Stream {station.stream_number}
+                                    </Text>
+                                    <Text style={styles.streamCode}>
+                                        {station.code}
+                                    </Text>
+                                </View>
+                                <View style={styles.streamVv}>
+                                    <Text style={styles.streamVvValue}>
+                                        {station.registered_voters.toLocaleString()}
+                                    </Text>
+                                    <Text style={styles.streamVvLabel}>VOTERS</Text>
+                                </View>
+                                <ChevronRight size={18} color={perk.copperDeep} />
+                            </TouchableOpacity>
+                        );
+                    })}
             </ScrollView>
         </SafeAreaView>
     );
 };
 
 export default ElectionResultsApp;
+
+const styles = StyleSheet.create({
+    screen: {
+        flex: 1,
+        backgroundColor: perk.card,
+        paddingTop: StatusBar.currentHeight || 0,
+    },
+    scroll: {
+        flex: 1,
+    },
+    content: {
+        paddingHorizontal: 20,
+        paddingTop: 12,
+        paddingBottom: 40,
+    },
+    centreCard: {
+        backgroundColor: perk.surface,
+        borderRadius: 14,
+        padding: 14,
+        marginBottom: 16,
+    },
+    centreName: {
+        fontSize: 16,
+        fontWeight: "900",
+        letterSpacing: -0.2,
+        textTransform: "uppercase",
+        color: perk.limeDeep,
+    },
+    centreMeta: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        color: perk.mute,
+        letterSpacing: 0.8,
+        marginTop: 3,
+        textTransform: "uppercase",
+    },
+    centreStats: {
+        flexDirection: "row",
+        marginTop: 12,
+        paddingTop: 10,
+        borderTopWidth: 1,
+        borderTopColor: perk.rule08,
+    },
+    centreStat: {
+        flex: 1,
+        alignItems: "center",
+    },
+    centreStatValue: {
+        fontSize: 22,
+        fontWeight: "900",
+        letterSpacing: -0.4,
+        color: perk.ink,
+    },
+    centreStatLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        fontWeight: "700",
+        letterSpacing: 1.4,
+        color: perk.mute,
+        marginTop: 2,
+    },
+    sectionLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.8,
+        color: perk.ink,
+        marginBottom: 8,
+    },
+    streamRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        backgroundColor: perk.card,
+        borderWidth: 1.5,
+        borderColor: perk.ink,
+        borderRadius: 13,
+        paddingVertical: 11,
+        paddingHorizontal: 12,
+        marginBottom: 9,
+    },
+    streamRowLead: {},
+    streamNum: {
+        width: 40,
+        alignSelf: "stretch",
+        borderRadius: 9,
+        backgroundColor: perk.surface,
+        alignItems: "center",
+        justifyContent: "center",
+        paddingVertical: 6,
+    },
+    streamNumLead: {
+        backgroundColor: perk.lime,
+    },
+    streamNumValue: {
+        fontSize: 17,
+        fontWeight: "900",
+        color: perk.ink,
+    },
+    streamNumValueLead: {
+        color: perk.limeInk,
+    },
+    streamNumLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 7,
+        fontWeight: "700",
+        letterSpacing: 1,
+        color: perk.mute,
+        marginTop: 1,
+    },
+    streamNumLabelLead: {
+        color: perk.limeInk,
+    },
+    streamText: {
+        flex: 1,
+        minWidth: 0,
+    },
+    streamName: {
+        fontSize: 13,
+        fontWeight: "800",
+        letterSpacing: -0.2,
+        color: perk.ink,
+    },
+    streamCode: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        color: perk.mute,
+        letterSpacing: 0.6,
+        marginTop: 3,
+    },
+    streamVv: {
+        alignItems: "flex-end",
+    },
+    streamVvValue: {
+        fontSize: 15,
+        fontWeight: "900",
+        color: perk.ink,
+    },
+    streamVvLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 7,
+        fontWeight: "700",
+        letterSpacing: 1,
+        color: perk.mute,
+        marginTop: 1,
+    },
+});

--- a/NATIVE/app/(tabs)/index.tsx
+++ b/NATIVE/app/(tabs)/index.tsx
@@ -1,81 +1,29 @@
-import {Text, View} from "react-native";
-
-import Constants from "expo-constants";
 import React from "react";
 import ResultsLandingPage from "@/app/results";
 import {StatusBar} from "expo-status-bar";
+import {View} from "react-native";
+import {SafeAreaView} from "react-native-safe-area-context";
 import UpdateCheckerModal from "../_utils/updateModal";
+import {perk} from "@/app/_utils/colors";
 import {windowWidth} from "@/app/_utils/screenDimensions";
 
 const LandingComponent = () => {
     return (
-        <View
+        <SafeAreaView
             style={{
                 flex: 1,
                 width: 1 * windowWidth,
-                flexDirection: "column",
-                justifyContent: "space-between",
-                alignItems: "center",
-                // paddingTop: Constants.statusBarHeight,
+                backgroundColor: perk.card,
             }}
+            edges={["top"]}
         >
-            <StatusBar translucent />
+            <StatusBar style="dark" />
             <UpdateCheckerModal />
 
-            {/* content */}
-
-            <View
-                style={{
-                    flex: 1,
-                    justifyContent: "center",
-                    alignItems: "center",
-                    paddingTop: Constants.statusBarHeight,
-                    // borderWidth: 4,
-                }}
-            >
-                <View
-                    style={{
-                        flex: 1,
-                        flexDirection: "column",
-                        alignItems: "flex-start",
-                        // borderWidth: 4,
-                        width: 1 * windowWidth,
-                        paddingLeft: 12,
-                    }}
-                >
-                    <Text
-                        style={{
-                            fontSize: 32,
-                            marginBottom: 4,
-                            fontWeight: "bold",
-                            fontFamily: "Inter",
-                        }}
-                    >
-                        Kura Zetu
-                    </Text>
-                    <Text
-                        style={{
-                            fontSize: 16,
-                        }}
-                    >
-                        2027 Election Coverage
-                    </Text>
-                </View>
-                <View
-                    style={{
-                        flex: 8,
-                        flexDirection: "column",
-                        justifyContent: "center",
-                        alignItems: "center",
-                        width: 1 * windowWidth,
-                        // backgroundColor: "white",
-                        backgroundColor: "rgba(0,0,0,0.3)",
-                    }}
-                >
-                    <ResultsLandingPage />
-                </View>
+            <View style={{flex: 1, width: 1 * windowWidth}}>
+                <ResultsLandingPage />
             </View>
-        </View>
+        </SafeAreaView>
     );
 };
 

--- a/NATIVE/app/auth/signUp.tsx
+++ b/NATIVE/app/auth/signUp.tsx
@@ -23,6 +23,8 @@ export function MapUpdates({routeStep = "county"}: {routeStep?: Step}) {
         wardName?: string;
     }>();
     const [counties, setCounties] = useState<ICountyFeature[] | null>(null);
+    const [countyLoadError, setCountyLoadError] = useState<string | null>(null);
+    const [countyLoadAttempt, setCountyLoadAttempt] = useState(0);
     const [selectedCounty, setSelectedCounty] = useState<number | null>(null);
     const [selectedCountyName, setSelectedCountyName] = useState<string | null>(null);
     const [constituencies, setConstituencies] = useState<
@@ -133,8 +135,18 @@ export function MapUpdates({routeStep = "county"}: {routeStep?: Step}) {
     };
 
     useEffect(() => {
-        fetch(`${apiBaseURL}/api/stations/counties/boundaries/`)
-            .then((response) => response.json())
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 15_000);
+
+        fetch(`${apiBaseURL}/api/stations/counties/boundaries/`, {
+            signal: controller.signal,
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
+                }
+                return response.json();
+            })
             .then((data) =>
                 setCounties(
                     (data?.features ?? []).filter(
@@ -145,8 +157,20 @@ export function MapUpdates({routeStep = "county"}: {routeStep?: Step}) {
                     ),
                 ),
             )
-            .catch(() => setCounties([]));
-    }, []);
+            .catch(() => {
+                if (!controller.signal.aborted) {
+                    setCountyLoadError("Could not load map data. Check your connection and try again.");
+                } else {
+                    setCountyLoadError("Loading map data took too long. Please try again.");
+                }
+            })
+            .finally(() => clearTimeout(timeout));
+
+        return () => {
+            clearTimeout(timeout);
+            controller.abort();
+        };
+    }, [countyLoadAttempt]);
 
     useEffect(() => {
         if (step === "constituency" && params.county) {
@@ -254,7 +278,16 @@ export function MapUpdates({routeStep = "county"}: {routeStep?: Step}) {
                 ? (wards?.features ?? [])
                 : [];
 
-    if (counties === null) return <Loading />;
+    if (counties === null)
+        return (
+            <Loading
+                error={countyLoadError}
+                onRetry={() => {
+                    setCountyLoadError(null);
+                    setCountyLoadAttempt((attempt) => attempt + 1);
+                }}
+            />
+        );
 
     return (
         <View style={styles.screen}>
@@ -420,7 +453,7 @@ export function MapUpdates({routeStep = "county"}: {routeStep?: Step}) {
     );
 }
 
-function Loading() {
+function Loading({error, onRetry}: {error: string | null; onRetry: () => void}) {
     return (
         <View style={styles.loading}>
             <LottieComponent
@@ -430,8 +463,13 @@ function Loading() {
             />
             <Text style={styles.loadingTitle}>Loading map data</Text>
             <Text style={styles.loadingText}>
-                Fetching the latest boundaries and polling centres.
+                {error ?? "Fetching the latest boundaries and polling centres."}
             </Text>
+            {error ? (
+                <TouchableOpacity onPress={onRetry} style={styles.retryButton}>
+                    <Text style={styles.retryText}>Try again</Text>
+                </TouchableOpacity>
+            ) : null}
         </View>
     );
 }
@@ -549,6 +587,14 @@ const styles = StyleSheet.create({
         color: perk.mute,
         textAlign: "center",
     },
+    retryButton: {
+        marginTop: 20,
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+        borderRadius: 10,
+        backgroundColor: perk.lime,
+    },
+    retryText: {fontSize: 15, fontWeight: "800", color: perk.limeInk},
 });
 
 export default function SignupEntry() {

--- a/NATIVE/app/results/index.tsx
+++ b/NATIVE/app/results/index.tsx
@@ -1,5 +1,8 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {
+    Animated,
+    NativeScrollEvent,
+    NativeSyntheticEvent,
     ScrollView,
     StyleSheet,
     Text,
@@ -9,6 +12,7 @@ import {
 } from "react-native";
 
 import {BarChart} from "react-native-gifted-charts";
+import {ChevronDown} from "lucide-react-native";
 import {perk} from "@/app/_utils/colors";
 
 //TODO: Pull the data from the API
@@ -55,7 +59,7 @@ const offices = [
             {value: 8000, label: "Candidate 3", frontColor: perk.periwinkleDeep},
         ],
     },
-      {
+    {
         key: "mp",
         tab: "MP",
         title: "MP results",
@@ -82,108 +86,166 @@ const offices = [
 export default function ResultsLandingPage() {
     const {width: screenWidth} = useWindowDimensions();
     const [officeIndex, setOfficeIndex] = useState<number>(0);
+    const [showHint, setShowHint] = useState(true);
+    const [bob] = useState(() => new Animated.Value(0));
 
     const totalPresVotes = presidentialData.reduce((sum, c) => sum + c.votes, 0);
     const maxPresVotes = Math.max(...presidentialData.map((c) => c.votes));
 
     const activeOffice = offices[officeIndex];
 
+    useEffect(() => {
+        const loop = Animated.loop(
+            Animated.sequence([
+                Animated.timing(bob, {
+                    toValue: 1,
+                    duration: 750,
+                    useNativeDriver: true,
+                }),
+                Animated.timing(bob, {
+                    toValue: 0,
+                    duration: 750,
+                    useNativeDriver: true,
+                }),
+            ]),
+        );
+        loop.start();
+        return () => loop.stop();
+    }, [bob]);
+
+    const onPresScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const {contentOffset, contentSize, layoutMeasurement} = e.nativeEvent;
+        const atBottom =
+            contentOffset.y + layoutMeasurement.height >= contentSize.height - 8;
+        setShowHint(!atBottom);
+    };
+
     return (
-        <ScrollView
-            style={styles.container}
-            contentContainerStyle={styles.content}
-            showsVerticalScrollIndicator={false}
-        >
-            {/* Brand row */}
-            <View style={styles.brandRow}>
-                <View>
-                    <Text style={styles.brandName}>KuraZetu</Text>
-                    <Text style={styles.brandTag}>2027 ELECTION COVERAGE</Text>
-                </View>
-                <View style={styles.updatedCol}>
-                    <Text style={styles.updated}>2 MIN AGO</Text>
-                    <View style={styles.coverage}>
-                        <Text style={styles.coverageLabel}>87% IN</Text>
-                        <View style={styles.coverageBar}>
-                            <View style={[styles.coverageFill, {width: "87%"}]} />
+        <View style={styles.container}>
+            <View style={styles.content}>
+                {/* Brand row */}
+                <View style={styles.brandRow}>
+                    <View>
+                        <Text style={styles.brandName}>KuraZetu</Text>
+                        <Text style={styles.brandTag}>2027 ELECTION COVERAGE</Text>
+                    </View>
+                    <View style={styles.updatedCol}>
+                        <Text style={styles.updated}>2 MIN AGO</Text>
+                        <View style={styles.coverage}>
+                            <Text style={styles.coverageLabel}>87% IN</Text>
+                            <View style={styles.coverageBar}>
+                                <View style={[styles.coverageFill, {width: "87%"}]} />
+                            </View>
                         </View>
                     </View>
                 </View>
-            </View>
 
-            {/* Presidential results */}
-            <Text style={styles.sectionLabel}>PRESIDENTIAL RESULTS</Text>
-            {presidentialData.map((candidate) => {
-                const pct = ((candidate.votes / totalPresVotes) * 100).toFixed(1);
-                const barPct = (candidate.votes / maxPresVotes) * 100;
-                return (
-                    <View key={candidate.name} style={styles.presCard}>
-                        <Text style={styles.presPct}>{pct}%</Text>
-                        <Text style={styles.presName}>
-                            {candidate.name} · {candidate.party}
-                        </Text>
-                        <Text style={styles.presVotes}>
-                            {candidate.votes.toLocaleString()} VOTES
-                        </Text>
-                        <View style={styles.presBarTrack}>
-                            <View
-                                style={[
-                                    styles.presBarFill,
-                                    {
-                                        width: `${barPct}%`,
-                                        backgroundColor: candidate.color,
-                                    },
-                                ]}
-                            />
-                        </View>
-                    </View>
-                );
-            })}
-
-            {/* Office tabs */}
-            <View style={styles.officeTabs}>
-                {offices.map((office, idx) => {
-                    const on = idx === officeIndex;
-                    return (
-                        <TouchableOpacity
-                            key={office.key}
-                            style={[styles.officeTab, on && styles.officeTabOn]}
-                            onPress={() => setOfficeIndex(idx)}
-                            activeOpacity={0.8}
+                {/* Presidential results */}
+                <Text style={styles.sectionLabel}>PRESIDENTIAL RESULTS</Text>
+                <View style={styles.presScrollWrap}>
+                    <ScrollView
+                        style={styles.presScroll}
+                        showsVerticalScrollIndicator={false}
+                        onScroll={onPresScroll}
+                        scrollEventThrottle={16}
+                    >
+                        {presidentialData.map((candidate) => {
+                            const pct = (
+                                (candidate.votes / totalPresVotes) *
+                                100
+                            ).toFixed(1);
+                            const barPct = (candidate.votes / maxPresVotes) * 100;
+                            return (
+                                <View key={candidate.name} style={styles.presCard}>
+                                    <Text style={styles.presPct}>{pct}%</Text>
+                                    <Text style={styles.presName}>
+                                        {candidate.name} · {candidate.party}
+                                    </Text>
+                                    <Text style={styles.presVotes}>
+                                        {candidate.votes.toLocaleString()} VOTES
+                                    </Text>
+                                    <View style={styles.presBarTrack}>
+                                        <View
+                                            style={[
+                                                styles.presBarFill,
+                                                {
+                                                    width: `${barPct}%`,
+                                                    backgroundColor: candidate.color,
+                                                },
+                                            ]}
+                                        />
+                                    </View>
+                                </View>
+                            );
+                        })}
+                    </ScrollView>
+                    {showHint && (
+                        <Animated.View
+                            pointerEvents="none"
+                            style={[
+                                styles.scrollHint,
+                                {
+                                    transform: [
+                                        {
+                                            translateY: bob.interpolate({
+                                                inputRange: [0, 1],
+                                                outputRange: [0, 4],
+                                            }),
+                                        },
+                                    ],
+                                },
+                            ]}
                         >
-                            <Text
-                                style={[
-                                    styles.officeTabText,
-                                    on && styles.officeTabTextOn,
-                                ]}
-                            >
-                                {office.tab}
-                            </Text>
-                        </TouchableOpacity>
-                    );
-                })}
-            </View>
+                            <ChevronDown size={14} color={perk.limeInk} />
+                        </Animated.View>
+                    )}
+                </View>
 
-            {/* Chart */}
-            <Text style={styles.chartTitle}>
-                {activeOffice.title}{" "}
-                <Text style={styles.chartGeo}>· {activeOffice.geo}</Text>
-            </Text>
-            <BarChart
-                data={activeOffice.data}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                barBorderTopLeftRadius={4}
-                barBorderTopRightRadius={4}
-                showValuesAsTopLabel
-                topLabelTextStyle={styles.chartTopLabel}
-                xAxisLabelTextStyle={styles.chartXLabel}
-            />
-        </ScrollView>
+                {/* Office tabs */}
+                <View style={styles.officeTabs}>
+                    {offices.map((office, idx) => {
+                        const on = idx === officeIndex;
+                        return (
+                            <TouchableOpacity
+                                key={office.key}
+                                style={[styles.officeTab, on && styles.officeTabOn]}
+                                onPress={() => setOfficeIndex(idx)}
+                                activeOpacity={0.8}
+                            >
+                                <Text
+                                    style={[
+                                        styles.officeTabText,
+                                        on && styles.officeTabTextOn,
+                                    ]}
+                                >
+                                    {office.tab}
+                                </Text>
+                            </TouchableOpacity>
+                        );
+                    })}
+                </View>
+
+                {/* Chart */}
+                <Text style={styles.chartTitle}>
+                    {activeOffice.title}{" "}
+                    <Text style={styles.chartGeo}>· {activeOffice.geo}</Text>
+                </Text>
+                <BarChart
+                    data={activeOffice.data}
+                    isAnimated
+                    rotateLabel
+                    animationDuration={500}
+                    yAxisLabelWidth={40}
+                    width={screenWidth - 80}
+                    adjustToWidth
+                    barBorderTopLeftRadius={4}
+                    barBorderTopRightRadius={4}
+                    showValuesAsTopLabel
+                    topLabelTextStyle={styles.chartTopLabel}
+                    xAxisLabelTextStyle={styles.chartXLabel}
+                />
+            </View>
+        </View>
     );
 }
 
@@ -258,6 +320,29 @@ const styles = StyleSheet.create({
         color: perk.ink,
         marginTop: 18,
         marginBottom: 10,
+    },
+    presScrollWrap: {
+        position: "relative",
+        maxHeight: 220,
+    },
+    presScroll: {
+        paddingRight: 28,
+    },
+    scrollHint: {
+        position: "absolute",
+        right: -8,
+        bottom: 4,
+        width: 22,
+        height: 22,
+        borderRadius: 11,
+        backgroundColor: perk.lime,
+        alignItems: "center",
+        justifyContent: "center",
+        shadowColor: perk.ink,
+        shadowOffset: {width: 0, height: 2},
+        shadowOpacity: 0.14,
+        shadowRadius: 4,
+        elevation: 3,
     },
     presCard: {
         backgroundColor: perk.surface,

--- a/NATIVE/app/results/index.tsx
+++ b/NATIVE/app/results/index.tsx
@@ -235,9 +235,14 @@ export default function ResultsLandingPage() {
                     isAnimated
                     rotateLabel
                     animationDuration={500}
-                    yAxisLabelWidth={40}
-                    width={screenWidth - 80}
+                    width={screenWidth - 40}
                     adjustToWidth
+                    hideYAxisText
+                    yAxisLabelWidth={0}
+                    yAxisThickness={0}
+                    hideRules
+                    xAxisColor={perk.ink}
+                    xAxisThickness={1.5}
                     barBorderTopLeftRadius={4}
                     barBorderTopRightRadius={4}
                     showValuesAsTopLabel

--- a/NATIVE/app/results/index.tsx
+++ b/NATIVE/app/results/index.tsx
@@ -1,336 +1,350 @@
-import {FlatList, StyleSheet, Text, View, useWindowDimensions} from "react-native";
-import React, {useState} from "react";
-import {SceneMap, TabBar, TabView} from "react-native-tab-view";
+import {useState} from "react";
+import {
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+    useWindowDimensions,
+} from "react-native";
 
 import {BarChart} from "react-native-gifted-charts";
+import {perk} from "@/app/_utils/colors";
 
 //TODO: Pull the data from the API
 const presidentialData = [
-    {name: "Candidate 1", party: "Party A", votes: 5400000, color: "#2a9d8f"},
-    {name: "Candidate 2", party: "Party B", votes: 4800000, color: "#e76f51"},
-    {name: "Candidate 3", party: "Party C", votes: 3200000, color: "#f4a261"},
-    {name: "Candidate 4", party: "Party D", votes: 1500000, color: "#264653"},
+    {name: "Candidate 1", party: "Party A", votes: 5400000, color: perk.limeDeep},
+    {name: "Candidate 2", party: "Party B", votes: 4800000, color: perk.coralDeep},
+    {name: "Candidate 3", party: "Party C", votes: 2100000, color: perk.copper},
 ];
 
-const GovernorData = [
-    {value: 35000, label: "Candidate 1", frontColor: "#2a9d8f"},
-    {value: 27000, label: "Candidate 2", frontColor: "#e76f51"},
-    {value: 18000, label: "Candidate 3", frontColor: "#f4a261"},
-    {value: 12000, label: "Candidate 4", frontColor: "#264653"},
-    {value: 8000, label: "Candidate 5", frontColor: "#2a9d8f"},
-];
-const SenatorData = [
-    {value: 30000, label: "Candidate 1", frontColor: "#2a9d8f"},
-    {value: 25000, label: "Candidate 2", frontColor: "#e76f51"},
-    {value: 20000, label: "Candidate 3", frontColor: "#f4a261"},
-];
+const offices = [
+    {
+        key: "governor",
+        tab: "Gov",
+        title: "Governor results",
+        geo: "Laikipia County",
+        data: [
+            {value: 35010, label: "W. Kiptanui", frontColor: perk.limeDeep},
+            {value: 27140, label: "A. Cheserek", frontColor: perk.copper},
+            {value: 17860, label: "J. Lelei", frontColor: perk.periwinkleDeep},
+            {value: 11780, label: "M. Kones", frontColor: perk.ink},
+            {value: 7490, label: "P. Tanui", frontColor: perk.green},
+        ],
+    },
+    {
+        key: "senator",
+        tab: "Sen",
+        title: "Senator results",
+        geo: "Laikipia County",
+        data: [
+            {value: 30000, label: "Candidate 1", frontColor: perk.limeDeep},
+            {value: 25000, label: "Candidate 2", frontColor: perk.copper},
+            {value: 20000, label: "Candidate 3", frontColor: perk.periwinkleDeep},
+        ],
+    },
 
-const MpData = [
-    {value: 5000, label: "Candidate 1", frontColor: "#2a9d8f"},
-    {value: 2500, label: "Candidate 2", frontColor: "#e76f51"},
-    {value: 10000, label: "Candidate 3", frontColor: "#f4a261"},
-];
-
-const WomanRepData = [
-    {value: 15000, label: "Candidate 1", frontColor: "#2a9d8f"},
-    {value: 12000, label: "Candidate 2", frontColor: "#e76f51"},
-    {value: 8000, label: "Candidate 3", frontColor: "#f4a261"},
-];
-
-const MCAData = [
-    {value: 5000, label: "Candidate 1", frontColor: "#2a9d8f"},
-    {value: 2500, label: "Candidate 2", frontColor: "#e76f51"},
-    {value: 10000, label: "Candidate 3", frontColor: "#f4a261"},
+    {
+        key: "womanRep",
+        tab: "WR",
+        title: "Woman Rep results",
+        geo: "Laikipia County",
+        data: [
+            {value: 15000, label: "Candidate 1", frontColor: perk.limeDeep},
+            {value: 12000, label: "Candidate 2", frontColor: perk.copper},
+            {value: 8000, label: "Candidate 3", frontColor: perk.periwinkleDeep},
+        ],
+    },
+      {
+        key: "mp",
+        tab: "MP",
+        title: "MP results",
+        geo: "Laikipia East",
+        data: [
+            {value: 10000, label: "Candidate 1", frontColor: perk.limeDeep},
+            {value: 5000, label: "Candidate 2", frontColor: perk.copper},
+            {value: 2500, label: "Candidate 3", frontColor: perk.periwinkleDeep},
+        ],
+    },
+    {
+        key: "mca",
+        tab: "MCA",
+        title: "MCA results",
+        geo: "Nanyuki Ward",
+        data: [
+            {value: 10000, label: "Candidate 1", frontColor: perk.limeDeep},
+            {value: 5000, label: "Candidate 2", frontColor: perk.copper},
+            {value: 2500, label: "Candidate 3", frontColor: perk.periwinkleDeep},
+        ],
+    },
 ];
 
 export default function ResultsLandingPage() {
-    const {width: screenWidth, height: screenHeight} = useWindowDimensions();
+    const {width: screenWidth} = useWindowDimensions();
+    const [officeIndex, setOfficeIndex] = useState<number>(0);
 
-    const GovernorRoute = () => (
-        <View
-            style={{
-                flexDirection: "column",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                backgroundColor: "#fefe",
-            }}
-        >
-            <View style={{paddingVertical: 2}}>
-                <Text
-                    style={{
-                        fontSize: 20,
-                        marginVertical: 10,
-                    }}
-                >
-                    Governor Results
-                </Text>
-            </View>
-            <BarChart
-                data={GovernorData}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                xAxisLabelTextStyle={{
-                    fontSize: 8,
-                    color: "#264653",
-                }}
-            />
-        </View>
-    );
+    const totalPresVotes = presidentialData.reduce((sum, c) => sum + c.votes, 0);
+    const maxPresVotes = Math.max(...presidentialData.map((c) => c.votes));
 
-    const SenatorRoute = () => (
-        <View
-            style={{
-                flexDirection: "column",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                backgroundColor: "#fefe",
-            }}
-        >
-            <View style={{paddingVertical: 10}}>
-                <Text
-                    style={{
-                        fontSize: 28,
-                        marginVertical: 10,
-                    }}
-                >
-                    Senator Results
-                </Text>
-            </View>
-            <BarChart
-                data={SenatorData}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                xAxisLabelTextStyle={{
-                    fontSize: 12,
-                    color: "#264653",
-                }}
-                xAxisLabelsAtBottom={false}
-            />
-        </View>
-    );
-
-    const WomanRepRoute = () => (
-        <View
-            style={{
-                flexDirection: "column",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                backgroundColor: "#fefe",
-            }}
-        >
-            <View style={{paddingVertical: 10}}>
-                <Text
-                    style={{
-                        fontSize: 28,
-                        marginVertical: 10,
-                    }}
-                >
-                    Woman Rep Results
-                </Text>
-            </View>
-            <BarChart
-                data={WomanRepData}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                xAxisLabelTextStyle={{
-                    fontSize: 12,
-                    color: "#264653",
-                }}
-                xAxisLabelsAtBottom={false}
-            />
-        </View>
-    );
-
-    const MpRoute = () => (
-        <View
-            style={{
-                flexDirection: "column",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                backgroundColor: "#fefe",
-            }}
-        >
-            <View style={{paddingVertical: 10}}>
-                <Text
-                    style={{
-                        fontSize: 28,
-                        marginVertical: 10,
-                    }}
-                >
-                    MP Results
-                </Text>
-            </View>
-            <BarChart
-                data={MpData}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                xAxisLabelTextStyle={{
-                    fontSize: 12,
-                    color: "#264653",
-                }}
-                xAxisLabelsAtBottom={false}
-            />
-        </View>
-    );
-
-    const MCARoute = () => (
-        <View
-            style={{
-                flexDirection: "column",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                backgroundColor: "#fefe",
-            }}
-        >
-            <View style={{paddingVertical: 10}}>
-                <Text
-                    style={{
-                        fontSize: 28,
-                        marginVertical: 10,
-                    }}
-                >
-                    MCA Results
-                </Text>
-            </View>
-            <BarChart
-                data={MCAData}
-                isAnimated
-                rotateLabel
-                animationDuration={500}
-                yAxisLabelWidth={40}
-                width={screenWidth - 80}
-                adjustToWidth
-                xAxisLabelTextStyle={{
-                    fontSize: 12,
-                    color: "#264653",
-                }}
-                xAxisLabelsAtBottom={false}
-            />
-        </View>
-    );
-
-    const [index, setIndex] = useState<number>(0);
-    const [routes] = useState([
-        {key: "governor", title: "Governor"},
-        {key: "senator", title: "Senator"},
-        {key: "mp", title: "MP"},
-        {key: "womanRep", title: "Woman Rep"},
-        {key: "mca", title: "MCA"},
-    ]);
-
-    const renderScene = SceneMap({
-        governor: GovernorRoute,
-        senator: SenatorRoute,
-        mp: MpRoute,
-        womanRep: WomanRepRoute,
-        mca: MCARoute,
-    });
+    const activeOffice = offices[officeIndex];
 
     return (
-        <View style={styles.container}>
-            <View style={styles.headerContainer}>
-                <Text style={styles.header}>Presidential (Dummy) Results</Text>
-                <FlatList
-                    data={presidentialData}
-                    keyExtractor={(item) => item.name}
-                    contentContainerStyle={styles.flatListContainer}
-                    renderItem={({item}) => (
-                        <View style={styles.resultBox}>
-                            <Text style={{fontWeight: "bold"}}>
-                                {item.name} ({item.party})
-                            </Text>
-                            <Text>{item.votes.toLocaleString()} votes</Text>
+        <ScrollView
+            style={styles.container}
+            contentContainerStyle={styles.content}
+            showsVerticalScrollIndicator={false}
+        >
+            {/* Brand row */}
+            <View style={styles.brandRow}>
+                <View>
+                    <Text style={styles.brandName}>KuraZetu</Text>
+                    <Text style={styles.brandTag}>2027 ELECTION COVERAGE</Text>
+                </View>
+                <View style={styles.updatedCol}>
+                    <Text style={styles.updated}>2 MIN AGO</Text>
+                    <View style={styles.coverage}>
+                        <Text style={styles.coverageLabel}>87% IN</Text>
+                        <View style={styles.coverageBar}>
+                            <View style={[styles.coverageFill, {width: "87%"}]} />
+                        </View>
+                    </View>
+                </View>
+            </View>
+
+            {/* Presidential results */}
+            <Text style={styles.sectionLabel}>PRESIDENTIAL RESULTS</Text>
+            {presidentialData.map((candidate) => {
+                const pct = ((candidate.votes / totalPresVotes) * 100).toFixed(1);
+                const barPct = (candidate.votes / maxPresVotes) * 100;
+                return (
+                    <View key={candidate.name} style={styles.presCard}>
+                        <Text style={styles.presPct}>{pct}%</Text>
+                        <Text style={styles.presName}>
+                            {candidate.name} · {candidate.party}
+                        </Text>
+                        <Text style={styles.presVotes}>
+                            {candidate.votes.toLocaleString()} VOTES
+                        </Text>
+                        <View style={styles.presBarTrack}>
                             <View
                                 style={[
-                                    styles.bar,
+                                    styles.presBarFill,
                                     {
-                                        backgroundColor: item.color,
-                                        width: `${Math.min((item.votes / 100000) * 100, 100)}%`,
+                                        width: `${barPct}%`,
+                                        backgroundColor: candidate.color,
                                     },
                                 ]}
                             />
                         </View>
-                    )}
-                    showsVerticalScrollIndicator={false}
-                    bounces={true}
-                />
+                    </View>
+                );
+            })}
+
+            {/* Office tabs */}
+            <View style={styles.officeTabs}>
+                {offices.map((office, idx) => {
+                    const on = idx === officeIndex;
+                    return (
+                        <TouchableOpacity
+                            key={office.key}
+                            style={[styles.officeTab, on && styles.officeTabOn]}
+                            onPress={() => setOfficeIndex(idx)}
+                            activeOpacity={0.8}
+                        >
+                            <Text
+                                style={[
+                                    styles.officeTabText,
+                                    on && styles.officeTabTextOn,
+                                ]}
+                            >
+                                {office.tab}
+                            </Text>
+                        </TouchableOpacity>
+                    );
+                })}
             </View>
 
-            <View style={styles.tabViewContainer}>
-                <TabView
-                    navigationState={{index, routes}}
-                    renderScene={renderScene}
-                    onIndexChange={setIndex}
-                    initialLayout={{width: screenWidth}}
-                    renderTabBar={(props) => (
-                        <TabBar {...props} style={{backgroundColor: "#264653"}} />
-                    )}
-                />
-            </View>
-        </View>
+            {/* Chart */}
+            <Text style={styles.chartTitle}>
+                {activeOffice.title}{" "}
+                <Text style={styles.chartGeo}>· {activeOffice.geo}</Text>
+            </Text>
+            <BarChart
+                data={activeOffice.data}
+                isAnimated
+                rotateLabel
+                animationDuration={500}
+                yAxisLabelWidth={40}
+                width={screenWidth - 80}
+                adjustToWidth
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                showValuesAsTopLabel
+                topLabelTextStyle={styles.chartTopLabel}
+                xAxisLabelTextStyle={styles.chartXLabel}
+            />
+        </ScrollView>
     );
 }
 
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: "#f0f0f0",
+        backgroundColor: perk.card,
     },
-    headerContainer: {
-        flex: 3,
+    content: {
+        paddingHorizontal: 20,
+        paddingTop: 20,
+        paddingBottom: 40,
     },
-    header: {
-        fontSize: 24,
-        fontWeight: "bold",
-        textAlign: "center",
-        marginBottom: 10,
-        color: "#264653",
+    brandRow: {
+        flexDirection: "row",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
     },
-    flatListContainer: {
-        padding: 10,
-        borderRadius: 8,
+    brandName: {
+        fontSize: 22,
+        fontWeight: "900",
+        letterSpacing: -0.4,
+        color: perk.ink,
     },
-    resultBox: {
-        backgroundColor: "#fff",
-        marginHorizontal: 15,
-        padding: 10,
-        borderRadius: 8,
-        elevation: 2,
-        marginBottom: 10,
+    brandTag: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        fontWeight: "700",
+        letterSpacing: 1.6,
+        color: perk.copperDeep,
+        marginTop: 2,
     },
-    bar: {
-        height: 10,
-        marginTop: 5,
-        borderRadius: 5,
+    updatedCol: {
+        alignItems: "flex-end",
+        gap: 5,
     },
-    tabViewContainer: {
-        flex: 7,
+    updated: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        fontWeight: "700",
+        letterSpacing: 0.6,
+        color: perk.mute,
     },
-    chartContainer: {
-        flex: 1,
-        justifyContent: "center",
+    coverage: {
+        flexDirection: "row",
         alignItems: "center",
-        backgroundColor: "#f0f0f0",
+        gap: 6,
     },
-    sectionTitle: {
-        fontSize: 18,
-        marginVertical: 10,
-        fontWeight: "600",
+    coverageLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 9,
+        fontWeight: "700",
+        color: perk.greenDeep,
+    },
+    coverageBar: {
+        width: 44,
+        height: 4,
+        borderRadius: 2,
+        backgroundColor: perk.paperDeep,
+        overflow: "hidden",
+    },
+    coverageFill: {
+        height: "100%",
+        borderRadius: 2,
+        backgroundColor: perk.green,
+    },
+    sectionLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 10,
+        fontWeight: "700",
+        letterSpacing: 1.8,
+        color: perk.ink,
+        marginTop: 18,
+        marginBottom: 10,
+    },
+    presCard: {
+        backgroundColor: perk.surface,
+        borderRadius: 12,
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+        marginBottom: 10,
+    },
+    presPct: {
+        position: "absolute",
+        top: 12,
+        right: 14,
+        fontSize: 17,
+        fontWeight: "900",
+        letterSpacing: -0.3,
+        color: perk.ink,
+    },
+    presName: {
+        fontSize: 14,
+        fontWeight: "800",
+        letterSpacing: -0.2,
+        color: perk.ink,
+        paddingRight: 50,
+    },
+    presVotes: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 11,
+        color: perk.mute,
+        marginTop: 2,
+    },
+    presBarTrack: {
+        marginTop: 8,
+        height: 6,
+        borderRadius: 3,
+        backgroundColor: perk.paperDeep,
+        overflow: "hidden",
+    },
+    presBarFill: {
+        height: "100%",
+        borderRadius: 3,
+    },
+    officeTabs: {
+        flexDirection: "row",
+        backgroundColor: perk.surface,
+        borderRadius: 10,
+        overflow: "hidden",
+        marginTop: 16,
+        marginBottom: 16,
+    },
+    officeTab: {
+        flex: 1,
+        alignItems: "center",
+        paddingVertical: 9,
+        borderBottomWidth: 3,
+        borderBottomColor: "transparent",
+    },
+    officeTabOn: {
+        backgroundColor: perk.card,
+        borderBottomColor: perk.limeDeep,
+    },
+    officeTabText: {
+        fontSize: 11,
+        fontWeight: "700",
+        color: perk.mute,
+    },
+    officeTabTextOn: {
+        color: perk.ink,
+    },
+    chartTitle: {
+        fontSize: 15,
+        fontWeight: "800",
+        letterSpacing: -0.2,
+        color: perk.ink,
+        marginBottom: 12,
+    },
+    chartGeo: {
+        color: perk.copperDeep,
+        fontWeight: "700",
+    },
+    chartTopLabel: {
+        fontSize: 9,
+        fontWeight: "900",
+        color: perk.ink,
+    },
+    chartXLabel: {
+        fontFamily: "SpaceMono-Regular",
+        fontSize: 8,
+        color: perk.mute,
     },
 });

--- a/NATIVE/app/types.ts
+++ b/NATIVE/app/types.ts
@@ -17,20 +17,10 @@ export interface ICountyFeatureCollection {
 }
 
 export type TLevelTabs =
-    | "president"
-    | "governor"
-    | "senator"
-    | "womanRep"
-    | "mp"
-    | "mca";
+    "president" | "governor" | "senator" | "womanRep" | "mp" | "mca";
 
 export type TLevelDjango =
-    | "president"
-    | "governor"
-    | "senator"
-    | "mp"
-    | "women_rep"
-    | "mca";
+    "president" | "governor" | "senator" | "mp" | "women_rep" | "mca";
 
 export interface ICandidateDetails {
     id: number;
@@ -92,10 +82,8 @@ export interface ICountyPresResults {
 }
 
 export interface IPollingStationPresResults {
-    polling_station: IPollingStationData;
-    presidential_candidate: ICandidateDetails;
+    candidate: ICandidateDetails;
     votes: number;
-    is_verified: boolean;
 }
 
 export default {};

--- a/NATIVE/package.json
+++ b/NATIVE/package.json
@@ -21,6 +21,7 @@
         "expo-constants": "~57.0.6",
         "expo-dev-client": "~57.0.7",
         "expo-device": "~57.0.1",
+        "expo-file-system": "~57.0.1",
         "expo-font": "~57.0.1",
         "expo-haptics": "~57.0.1",
         "expo-image": "~57.0.1",

--- a/NATIVE/plugins/withAndroidSliderFix.js
+++ b/NATIVE/plugins/withAndroidSliderFix.js
@@ -1,0 +1,27 @@
+const { withProjectBuildGradle } = require("expo/config-plugins");
+
+const MARKER = "// KURAZETU_REACT_NATIVE_SLIDER_FIX";
+const PATCH = `
+${MARKER}
+// Slider 5.2.0 omits this source directory with the Gradle version used by
+// React Native 0.86, leaving ReactSliderPackage out of the linked library.
+subprojects { project ->
+  if (project.name == "react-native-community_slider") {
+    project.afterEvaluate {
+      project.android.sourceSets.main.java.srcDir("src/main/java")
+    }
+  }
+}
+`;
+
+module.exports = function withAndroidSliderFix(config) {
+  return withProjectBuildGradle(config, (config) => {
+    if (!config.modResults.contents.includes(MARKER)) {
+      config.modResults.contents = config.modResults.contents.replace(
+        'apply plugin: "expo-root-project"',
+        `${PATCH}\napply plugin: "expo-root-project"`,
+      );
+    }
+    return config;
+  });
+};

--- a/src/results/api/urls.py
+++ b/src/results/api/urls.py
@@ -9,6 +9,7 @@ from results.api.views import (
     PollingCenterPresidentialResultsAPIView,
     PollingCenterSenatorResultsAPIView,
     PollingCenterWomenRepResultsAPIView,
+    PollingStationLevelResultsAPIView,
     PollingStationPresidentialResultsAPIView,
     PollingStationCandidatesListAPIView,
     PollingStationResultsCreateAPIView,
@@ -60,6 +61,11 @@ urlpatterns = [
         "polling-station/<str:polling_station_code>/presidential/",
         PollingStationPresidentialResultsAPIView.as_view(),
         name="polling-station-presidential-results",
+    ),
+    path(
+        "polling-station/<str:polling_station_code>/results/<str:level>/",
+        PollingStationLevelResultsAPIView.as_view(),
+        name="polling-station-level-results",
     ),
     path(
         "polling-station/aspirants/<str:polling_station_code>/<str:level>/",

--- a/src/results/api/views.py
+++ b/src/results/api/views.py
@@ -436,6 +436,125 @@ class TotalPresResultsAPIView(APIView):
         )
 
 
+class PollingStationLevelResultsAPIView(APIView):
+    """
+    Return the tally for a single elective office (level) at a polling station.
+
+    The level is part of the URL path (``.../results/<level>/``) so each office
+    gets its own cache key. Output is normalised to a common ``candidate``/``votes``
+    shape regardless of office. Presidential additionally returns ``extra_data``
+    (Form 34A, rejected/disputed/valid votes); other offices have none.
+    """
+
+    authentication_classes = [
+        TokenAuthentication,
+        SessionAuthentication,
+    ]
+    permission_classes = [IsAuthenticated]
+
+    # level -> (results model, results serializer, candidate FK field name)
+    LEVEL_CONFIG = {
+        "president": (
+            PollingStationPresidentialResults,
+            PollingStationPresidentialResultsSerializer,
+            "presidential_candidate",
+        ),
+        "governor": (
+            PollingStationGovernorResults,
+            PollingStationGovernorResultsSerializer,
+            "governor_candidate",
+        ),
+        "senator": (
+            PollingStationSenatorResults,
+            PollingStationSenatorResultsSerializer,
+            "senator_candidate",
+        ),
+        "women_rep": (
+            PollingStationWomenRepResults,
+            PollingStationWomenRepResultsSerializer,
+            "woman_rep_candidate",
+        ),
+        "mp": (
+            PollingStationMpResults,
+            PollingStationMpResultsSerializer,
+            "mp_candidate",
+        ),
+        "mca": (
+            PollingStationMCAResults,
+            PollingStationMCAResultsSerializer,
+            "mca_candidate",
+        ),
+    }
+
+    # 5 minutes. TODO: invalidate on submission instead of relying on expiry.
+    CACHE_TIMEOUT = 60 * 5
+
+    def get(self, request, *args, **kwargs):
+        # The native app uses "womanRep"; the Django level is "women_rep".
+        level = kwargs.get("level")
+        level = {"womanRep": "women_rep"}.get(level, level)
+
+        config = self.LEVEL_CONFIG.get(level)
+        if config is None:
+            return Response(
+                {"error": "Invalid level specified."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        polling_station_code = kwargs.get("polling_station_code")
+
+        # Per-level, per-station cache key. The level is in the URL path, so each
+        # office caches independently and can be invalidated on its own.
+        cache_key = f"polling_station_results:{level}:{polling_station_code}"
+        cached_payload = cache.get(cache_key)
+        if cached_payload is not None:
+            return Response(cached_payload)
+
+        model, serializer_class, candidate_field = config
+
+        try:
+            polling_station = PollingStation.objects.get(code=polling_station_code)
+        except PollingStation.DoesNotExist:
+            return Response(
+                {"error": "Polling station not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        results_qs = model.objects.filter(polling_station=polling_station).order_by(
+            "votes"
+        )
+        serializer = serializer_class(
+            results_qs, many=True, context={"request": request}
+        )
+
+        # Normalise the per-office candidate key to a common "candidate" field.
+        data = [
+            {"candidate": row[candidate_field], "votes": row["votes"]}
+            for row in serializer.data
+        ]
+
+        extra_data = None
+        if level == "president":
+            try:
+                polling_station_extras = PollingStationPresidentialExtras.objects.get(
+                    polling_station=polling_station
+                )
+                extra_data = PollingStationPresidentialExtrasSerializer(
+                    polling_station_extras, context={"request": request}
+                ).data
+            except PollingStationPresidentialExtras.DoesNotExist:
+                extra_data = None
+
+        payload = {
+            "data": data,
+            "extra_data": extra_data,
+            "status": status.HTTP_200_OK,
+        }
+        cache.set(cache_key, payload, timeout=self.CACHE_TIMEOUT)
+
+        return Response(payload)
+
+
 class PollingStationPresidentialResultsAPIView(APIView):
 
     authentication_classes = [

--- a/src/results/tests.py
+++ b/src/results/tests.py
@@ -1,9 +1,11 @@
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 import pytest
+from rest_framework.test import APIClient
 
 from results.models import (
     Aspirant,
@@ -11,6 +13,7 @@ from results.models import (
     PollingStationGovernorResults,
     PollingStationMCAResults,
     PollingStationMpResults,
+    PollingStationPresidentialExtras,
     PollingStationPresidentialResults,
     PollingStationSenatorResults,
     PollingStationWomenRepResults,
@@ -328,3 +331,167 @@ class TestPollingStationGovernorResultsModel:
             votes=100,
         )
         assert str(results) == f"{polling_station} - {aspirant} - 100"
+
+
+class TestPollingStationLevelResultsAPI:
+    """Tests for the per-level polling-station results endpoint."""
+
+    def url(self, code, level):
+        return f"/api/results/polling-station/{code}/results/{level}/"
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        # The view caches per (level, station); isolate each test.
+        cache.clear()
+        yield
+        cache.clear()
+
+    @pytest.fixture
+    def client(self, user):
+        api_client = APIClient()
+        api_client.force_authenticate(user=user)
+        return api_client
+
+    def test_requires_authentication(self, polling_station):
+        response = APIClient().get(self.url(polling_station.code, "governor"))
+        assert response.status_code == 401
+
+    def test_returns_normalised_governor_results(
+        self, client, party, county, polling_station
+    ):
+        leader = Aspirant.objects.create(
+            first_name="Ann",
+            last_name="Leader",
+            party=party,
+            level="governor",
+            county=county,
+        )
+        runner_up = Aspirant.objects.create(
+            first_name="Bob",
+            last_name="Runner",
+            party=party,
+            level="governor",
+            county=county,
+        )
+        PollingStationGovernorResults.objects.create(
+            polling_station=polling_station, governor_candidate=leader, votes=300
+        )
+        PollingStationGovernorResults.objects.create(
+            polling_station=polling_station, governor_candidate=runner_up, votes=120
+        )
+
+        response = client.get(self.url(polling_station.code, "governor"))
+
+        assert response.status_code == 200
+        data = response.data["data"]
+        assert len(data) == 2
+        # Normalised to a common "candidate" key regardless of office.
+        assert set(data[0].keys()) == {"candidate", "votes"}
+        assert data[0]["candidate"]["first_name"] in {"Ann", "Bob"}
+        # Non-presidential offices carry no extra_data.
+        assert response.data["extra_data"] is None
+
+    def test_president_includes_extra_data(
+        self, client, party, polling_station
+    ):
+        candidate = Aspirant.objects.create(
+            first_name="Prez",
+            last_name="Idential",
+            party=party,
+            level="president",
+        )
+        PollingStationPresidentialResults.objects.create(
+            polling_station=polling_station,
+            presidential_candidate=candidate,
+            votes=200,
+        )
+        PollingStationPresidentialExtras.objects.create(
+            polling_station=polling_station,
+            rejected_votes=2,
+            disputed_votes=1,
+            valid_votes_cast=200,
+        )
+
+        response = client.get(self.url(polling_station.code, "president"))
+
+        assert response.status_code == 200
+        assert len(response.data["data"]) == 1
+        assert response.data["extra_data"] is not None
+        assert response.data["extra_data"]["rejected_votes"] == 2
+        assert response.data["extra_data"]["valid_votes_cast"] == 200
+
+    def test_woman_rep_alias_is_accepted(
+        self, client, party, county, polling_station
+    ):
+        candidate = Aspirant.objects.create(
+            first_name="Wanjiku",
+            last_name="Rep",
+            party=party,
+            level="women_rep",
+            county=county,
+        )
+        PollingStationWomenRepResults.objects.create(
+            polling_station=polling_station,
+            woman_rep_candidate=candidate,
+            votes=50,
+        )
+
+        # The native app sends "womanRep"; it should map to "women_rep".
+        response = client.get(self.url(polling_station.code, "womanRep"))
+
+        assert response.status_code == 200
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["candidate"]["first_name"] == "Wanjiku"
+
+    def test_empty_results_return_empty_list(self, client, polling_station):
+        response = client.get(self.url(polling_station.code, "senator"))
+        assert response.status_code == 200
+        assert response.data["data"] == []
+        assert response.data["extra_data"] is None
+
+    def test_invalid_level_returns_400(self, client, polling_station):
+        response = client.get(self.url(polling_station.code, "president-for-life"))
+        assert response.status_code == 400
+
+    def test_unknown_station_returns_404(self, client):
+        response = client.get(self.url("000000000", "governor"))
+        assert response.status_code == 404
+
+    def test_response_is_cached_per_level_and_station(
+        self, client, party, county, polling_station
+    ):
+        candidate = Aspirant.objects.create(
+            first_name="Cache",
+            last_name="Me",
+            party=party,
+            level="governor",
+            county=county,
+        )
+        PollingStationGovernorResults.objects.create(
+            polling_station=polling_station,
+            governor_candidate=candidate,
+            votes=10,
+        )
+
+        cache_key = f"polling_station_results:governor:{polling_station.code}"
+        assert cache.get(cache_key) is None
+
+        first = client.get(self.url(polling_station.code, "governor"))
+        assert first.status_code == 200
+        # Cache is populated after the first request.
+        assert cache.get(cache_key) is not None
+
+        # A newly added result is not reflected until the cache expires.
+        PollingStationGovernorResults.objects.create(
+            polling_station=polling_station,
+            governor_candidate=Aspirant.objects.create(
+                first_name="Later",
+                last_name="Comer",
+                party=party,
+                level="governor",
+                county=county,
+            ),
+            votes=99,
+        )
+        second = client.get(self.url(polling_station.code, "governor"))
+        assert len(second.data["data"]) == 1


### PR DESCRIPTION
Restyles the native dashboard and the whole Stations tab to the perk design
system, and adds per-race results so each aspirant level opens its own tally.

### App
- Dashboard: perk brand header, scrollable presidential cards with scroll hint,
  office tab strip, y-axis-less bar chart.
- Stations: centre list, station race menu, and per-level results screen — all perk.
- Race rows now pass their `level` through navigation; results screen fetches
  that level, with a perk empty state + restyled FAB.
- Extracted a shared `Form34ACaptureForm` (dedupes AddFormModal +
  CounterEvidenceModal) with a safe-area fix and floating footer sheet.

### Backend
- New cached (5 min, per level+station) `polling-station/<code>/results/<level>/`
  endpoint returning a normalised `candidate`/`votes` shape; presidential also
  returns Form 34A extras.
- API tests for each level, the womanRep alias, empty results, invalid level,
  missing station, and caching.