### PR TITLE
[mobile] Adopt native tabs (Liquid glass and native android tabs)

### DIFF
--- a/NATIVE/app/(tabs)/_layout.tsx
+++ b/NATIVE/app/(tabs)/_layout.tsx
@@ -1,144 +1,64 @@
-import {
-    BarChart,
-    BinocularsIcon,
-    ChartSplineIcon,
-    ListFilter,
-    Map,
-    User,
-} from "lucide-react-native";
-import {Platform, StyleSheet, View} from "react-native";
+import {NativeTabs} from "expo-router/unstable-native-tabs";
+import {DynamicColorIOS, Platform} from "react-native";
 
-import {BlurView} from "expo-blur";
-import {Tabs} from "expo-router";
+const tabTintColor =
+    Platform.OS === "ios"
+        ? DynamicColorIOS({
+              light: "#1A2C4E",
+              dark: "#E9F0FF",
+          })
+        : "#1A2C4E";
 
-const TabBarIcon = ({
-    IconComponent,
-    focused,
-    color,
-    size,
-}: {
-    IconComponent: React.ComponentType<{color: string; size: number}>;
-    focused: boolean;
-    color: string;
-    size: number;
-}) => {
-    return (
-        <View style={[styles.iconContainer, focused && styles.activeIcon]}>
-            <IconComponent color={color} size={size} />
-        </View>
-    );
-};
+const tabLabelColor =
+    Platform.OS === "ios"
+        ? DynamicColorIOS({
+              light: "#1A2C4E",
+              dark: "#FFFFFF",
+          })
+        : "#1A2C4E";
 
 export default function TabLayout() {
     return (
-        <Tabs
-            screenOptions={{
-                headerShown: false,
-                tabBarStyle: {
-                    ...styles.tabBar,
-                    ...(Platform.OS === "web" ? {} : {backgroundColor: "transparent"}),
-                },
-                tabBarBackground: () =>
-                    Platform.OS !== "web" ? (
-                        <BlurView
-                            tint="light"
-                            intensity={80}
-                            style={StyleSheet.absoluteFill}
-                        />
-                    ) : null,
-                tabBarActiveTintColor: "#1A2C4E",
-                tabBarInactiveTintColor: "#8E8E93",
-                tabBarLabelStyle: styles.tabLabel,
-                tabBarItemStyle: styles.tabItem,
+        <NativeTabs
+            tintColor={tabTintColor}
+            labelStyle={{
+                color: tabLabelColor,
+                fontFamily: "Inter-Medium",
+                fontSize: 10,
             }}
+            indicatorColor="#E9F0FF"
+            labelVisibilityMode="labeled"
+            tabBarRespectsIMEInsets
+            minimizeBehavior="onScrollDown"
         >
-            <Tabs.Screen
-                name="index"
-                options={{
-                    title: "Dashboard",
-                    tabBarIcon: ({focused, color, size}) => (
-                        <TabBarIcon
-                            IconComponent={BarChart}
-                            focused={focused}
-                            color={color}
-                            size={size}
-                        />
-                    ),
-                }}
-            />
+            <NativeTabs.Trigger name="index">
+                <NativeTabs.Trigger.Icon
+                    sf={{default: "chart.bar.xaxis", selected: "chart.bar.xaxis"}}
+                    md="bar_chart"
+                />
+                <NativeTabs.Trigger.Label>Dashboard</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
 
-            <Tabs.Screen
-                name="pollingCentersEdit"
-                options={{
-                    title: "Verify",
-                    tabBarIcon: ({focused, color, size}) => (
-                        <TabBarIcon
-                            IconComponent={User}
-                            focused={focused}
-                            color={color}
-                            size={size}
-                        />
-                    ),
-                }}
-            />
+            <NativeTabs.Trigger name="pollingCentersEdit">
+                <NativeTabs.Trigger.Icon
+                    sf={{default: "person", selected: "person.fill"}}
+                    md="person"
+                />
+                <NativeTabs.Trigger.Label>Verify</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
 
-            <Tabs.Screen
-                name="communityNotes"
-                options={{
-                    title: "Stations",
-                    tabBarIcon: ({focused, color, size}) => (
-                        <TabBarIcon
-                            IconComponent={ChartSplineIcon}
-                            focused={focused}
-                            color={color}
-                            size={size}
-                        />
-                    ),
-                }}
-            />
+            <NativeTabs.Trigger name="communityNotes">
+                <NativeTabs.Trigger.Icon
+                    sf={{default: "chart.xyaxis.line", selected: "chart.xyaxis.line"}}
+                    md="query_stats"
+                />
+                <NativeTabs.Trigger.Label>Stations</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
 
-            <Tabs.Screen
-                name="settings/index"
-                options={{
-                    title: "Profile",
-                    tabBarIcon: ({focused, color, size}) => (
-                        <TabBarIcon
-                            IconComponent={ListFilter}
-                            focused={focused}
-                            color={color}
-                            size={size}
-                        />
-                    ),
-                }}
-            />
-        </Tabs>
+            <NativeTabs.Trigger name="settings/index">
+                <NativeTabs.Trigger.Icon sf="slider.horizontal.3" md="tune" />
+                <NativeTabs.Trigger.Label>Profile</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
+        </NativeTabs>
     );
 }
-
-const styles = StyleSheet.create({
-    tabBar: {
-        borderTopWidth: 0,
-        elevation: 0,
-        height: 90,
-        paddingBottom: 25,
-        paddingTop: 10,
-    },
-    tabLabel: {
-        fontFamily: "Inter-Medium",
-        fontSize: 10,
-        lineHeight: 12,
-    },
-    tabItem: {
-        paddingHorizontal: 0,
-    },
-    iconContainer: {
-        alignItems: "center",
-        justifyContent: "center",
-        width: 42,
-        height: 28,
-        borderRadius: 14,
-    },
-    activeIcon: {
-        backgroundColor: "#E9F0FF",
-    },
-});

--- a/NATIVE/app/_layout.tsx
+++ b/NATIVE/app/_layout.tsx
@@ -4,13 +4,13 @@ import "react-native-reanimated";
 import * as QuickActions from "expo-quick-actions";
 import * as SplashScreen from "expo-splash-screen";
 
-import {Image, PermissionsAndroid, Platform, StyleSheet, Text, View} from "react-native";
+import {Image, PermissionsAndroid, Platform, StyleSheet, Text, useColorScheme, View} from "react-native";
 import React, {useEffect} from "react";
 import {windowWidth} from "./_utils/screenDimensions";
 
 import {GestureHandlerRootView} from "react-native-gesture-handler";
 import LottieComponent from "@/components/lottieLoading";
-import {Stack} from "expo-router";
+import {DarkTheme, DefaultTheme, Stack, ThemeProvider} from "expo-router";
 import {StatusBar} from "expo-status-bar";
 import {useAuthStore} from "./_utils/authStore";
 import {useFonts} from "expo-font";
@@ -21,9 +21,10 @@ SplashScreen.preventAutoHideAsync();
 
 function RootLayoutNav() {
     const {isLoggedIn, shouldCreateAccount} = useAuthStore();
+    const colorScheme = useColorScheme();
 
     return (
-        <React.Fragment>
+        <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
             <StatusBar style="auto" />
             <Stack>
                 <Stack.Protected guard={!isLoggedIn}>
@@ -39,7 +40,7 @@ function RootLayoutNav() {
                     <Stack.Screen name="(tabs)" options={{headerShown: false}} />
                 </Stack.Protected>
             </Stack>
-        </React.Fragment>
+        </ThemeProvider>
     );
 }
 


### PR DESCRIPTION
  - Replaced the custom JavaScript/BlurView tab bar with Expo Router `NativeTabs`
  - Added native SF Symbols on iOS and Material Symbols on Android
  - Preserved the existing four tabs and nested route stacks
  - Added adaptive theming for iOS Liquid Glass, Android IME handling, and iOS
  tab-bar minimization

  ## Validation

  - Manually tested on iOS and Android