### PR TITLE
Pin black and isort so the hook and CI agree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         files: ^src/
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.1.0
     hooks:
       - id: black
         files: ^src/

--- a/docs/tutorials/setup.md
+++ b/docs/tutorials/setup.md
@@ -179,6 +179,12 @@ Create a virtual environment and install the required Python packages:
 ```
 ````
 
+```{important}
+`black`, `isort`, and `pytest-black` are pinned to exact versions in `src/requirements.txt`, and
+`.pre-commit-config.yaml` pins the same versions under `rev:`. Bump both together. If they drift,
+the hook reformats a file one way and the test suite's format check rejects it the other way.
+```
+
 ### Install System Dependencies
 
 Before proceeding, install the required system dependencies for PostgreSQL, PostGIS, and GeoDjango:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-black
+black==25.1.0
 crispy-tailwind
 django == 5.2.1
 django_browser_reload
@@ -13,7 +13,7 @@ djangorestframework == 3.15.2
 djangorestframework_gis
 drf-spectacular
 gunicorn
-isort
+isort==6.0.1
 markdown
 openpyxl
 pandas
@@ -21,7 +21,7 @@ phonenumbers
 pre-commit
 psycopg2-binary
 pytest == 8.3.5
-pytest-black
+pytest-black==0.6.0
 pytest-cov
 pytest-django
 pytest-sugar

--- a/src/stations/api/views.py
+++ b/src/stations/api/views.py
@@ -3,30 +3,30 @@ from django.db import transaction
 from django.db.models import F
 
 from rest_framework import status
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 
 from stations.api.serializers import (
+    CommunityNotesPollingCenterSerializer,
     ConstituencySerializer,
     CountySerializer,
-    PollingCenterSerializer,
-    WardSerializer,
-    PollingCenterBoundarySerializer,
     PartiallyVerifiedPollingCenterBoundarySerializer,
-    CommunityNotesPollingCenterSerializer,
-    PollingStationSerializer,
+    PollingCenterBoundarySerializer,
+    PollingCenterSerializer,
     PollingStationInfoSerializer,
+    PollingStationSerializer,
+    WardSerializer,
 )
 from stations.models import (
     Constituency,
     County,
     PollingCenter,
-    Ward,
     PollingCenterVerification,
     PollingStation,
+    Ward,
 )
 from stations.verification import recompute_consensus
 
@@ -154,14 +154,12 @@ class WardPollingCenterFromLocationListAPIView(APIView):
 
 
 class RandomUnverifiedPollingCenterAPIView(APIView):
-
     authentication_classes = [SessionAuthentication, TokenAuthentication]
     permission_classes = [AllowAny]
 
     serializer_class = PollingCenterSerializer
 
     def get(self, request, *args, **kwargs):
-
         user = self.request.user
         admin_level = kwargs.get("admin_level")
         print(user, "user inside the server")
@@ -352,10 +350,13 @@ class VerificationPollingCenterAPIView(APIView):
         print(isUpvote is True, "is upvote boolean value")
 
         if isUpvote is True:
-            if user.is_authenticated and PollingCenterVerification.objects.filter(
-                polling_center=polling_center,
-                verified_by=user,
-            ).exists():
+            if (
+                user.is_authenticated
+                and PollingCenterVerification.objects.filter(
+                    polling_center=polling_center,
+                    verified_by=user,
+                ).exists()
+            ):
                 return Response(
                     {"error": "You have already verified this polling center"},
                     status=status.HTTP_200_OK,
@@ -441,7 +442,9 @@ class AIPollingCenterVerificationAPIView(APIView):
 
         if not school_name or not ward_name or latitude is None or longitude is None:
             return Response(
-                {"error": "school_name, ward_name, latitude, and longitude are required fields."},
+                {
+                    "error": "school_name, ward_name, latitude, and longitude are required fields."
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -467,11 +470,17 @@ class AIPollingCenterVerificationAPIView(APIView):
 
         # 2. Lookup Polling Center in Ward
         try:
-            polling_center = PollingCenter.objects.get(ward=ward, name__iexact=school_name)
+            polling_center = PollingCenter.objects.get(
+                ward=ward, name__iexact=school_name
+            )
         except PollingCenter.DoesNotExist:
-            polling_center = PollingCenter.objects.filter(ward=ward, name__icontains=school_name).first()
+            polling_center = PollingCenter.objects.filter(
+                ward=ward, name__icontains=school_name
+            ).first()
             if not polling_center:
-                available_centers = PollingCenter.objects.filter(ward=ward).values_list("name", flat=True)
+                available_centers = PollingCenter.objects.filter(ward=ward).values_list(
+                    "name", flat=True
+                )
                 return Response(
                     {
                         "error": f"Polling Center (School) '{school_name}' not found in Ward '{ward.name}'.",
@@ -587,7 +596,6 @@ class CommunityNotesPollingCenterDetailsAPIView(APIView):
     serializer_class = CommunityNotesPollingCenterSerializer
 
     def get(self, *args, **kwargs):
-
         user = self.request.user
 
         print(user, "user inside the server")
@@ -654,9 +662,10 @@ class GeocodeAPIView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, *args, **kwargs):
-        import requests
         from django.conf import settings
         from django.core.cache import cache
+
+        import requests
 
         query = (request.query_params.get("q") or "").strip()
         ward_number = request.query_params.get("ward_number")
@@ -706,7 +715,12 @@ class GeocodeAPIView(APIView):
                         }
                     )
             else:
-                params = {"q": query, "format": "json", "limit": 6, "countrycodes": "ke"}
+                params = {
+                    "q": query,
+                    "format": "json",
+                    "limit": 6,
+                    "countrycodes": "ke",
+                }
                 if bbox:
                     params["viewbox"] = f"{bbox[0]},{bbox[1]},{bbox[2]},{bbox[3]}"
                     params["bounded"] = 1

--- a/src/stations/verification.py
+++ b/src/stations/verification.py
@@ -77,9 +77,7 @@ def recompute_consensus(polling_center):
     if not suggestions:
         return {"verified": False, "agree": 0, "needed": threshold, "outliers": 0}
 
-    ward_boundary = (
-        polling_center.ward.boundary if polling_center.ward_id else None
-    )
+    ward_boundary = polling_center.ward.boundary if polling_center.ward_id else None
 
     centroid = cluster_centroid([s.pin_location for s in suggestions])
 


### PR DESCRIPTION
Closes #77.

`.pre-commit-config.yaml` pinned black `23.12.1` / isort `5.13.2` while `src/requirements.txt` left them unpinned, so CI installed black `25.1.0` / isort `6.0.1`. The two format differently: the hook rewrote `stations/api/views.py` one way, `pytest-black` in CI rejected it the other way.

- Hook `rev:` bumped to the versions CI already installs
- `black`, `isort`, `pytest-black` pinned to exact versions in `requirements.txt`
- `stations/api/views.py` and `stations/verification.py` formatted (no logic change)
- Note in `setup.md` that both sides must be bumped together

Fixes the 2 `black` failures in `build (3.12)`.

## Testing

- `pytest accounts stations` — 50 passed locally
- `black --check` and `isort --check-only` clean on both modules

## Stacking

Targets `docs/agent-instructions`, not `main`: the fix edits `.pre-commit-config.yaml`, which only exists after `bd59e74` on that branch. Merge #76 first (PR8, PR9).
